### PR TITLE
Update App test for home page heading

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders home page heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByRole('heading', { name: /welcome to household manager/i });
+  expect(heading).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update `App.test.js` to assert that the home page heading appears

## Testing
- `npm test --workspaces=false --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d688d56d8832ea649e77dc81a6083