### PR TITLE
Update createUser comment

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -40,7 +40,7 @@ export const updateContract = updateService;
 export const deleteContract = deleteService;
 
 // --- Users ---
-// CHANGE createUser endpoint to /register for safe password hashing
+// createUser uses the /register endpoint for secure password hashing
 export const getUsers    = () => axios.get(`${API_URL}/users`);
 export const createUser  = data => axios.post(`${API_URL}/register`, data);
 export const updateUser  = (id, data) => axios.put(`${API_URL}/users/${id}`, data);


### PR DESCRIPTION
## Summary
- clarify that `createUser` calls the `/register` endpoint

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d688cfa00832eac768b3e3cc689bb