### PR TITLE
Fix create record API calls

### DIFF
--- a/frontend/src/modules/carManager/tabs/MileageTab.js
+++ b/frontend/src/modules/carManager/tabs/MileageTab.js
@@ -38,7 +38,7 @@ export default function MileageTab({ carId }) {
         })
         .catch(console.error);
     } else {
-      createMileageRecord({ ...record, CarId: carId })
+      createMileageRecord(carId, record)
         .then(() => {
           closeModal();
           loadRecords();

--- a/frontend/src/modules/carManager/tabs/MotTab.js
+++ b/frontend/src/modules/carManager/tabs/MotTab.js
@@ -38,7 +38,7 @@ export default function MotTab({ carId }) {
         })
         .catch(console.error);
     } else {
-      createMot({ ...record, CarId: carId })
+      createMot(carId, record)
         .then(() => {
           closeModal();
           loadRecords();

--- a/frontend/src/modules/carManager/tabs/ServiceTab.js
+++ b/frontend/src/modules/carManager/tabs/ServiceTab.js
@@ -38,7 +38,7 @@ export default function ServiceTab({ carId }) {
         })
         .catch(console.error);
     } else {
-      createServiceRecord({ ...record, CarId: carId })
+      createServiceRecord(carId, record)
         .then(() => {
           closeModal();
           loadRecords();

--- a/frontend/src/modules/carManager/tabs/TaxTab.js
+++ b/frontend/src/modules/carManager/tabs/TaxTab.js
@@ -38,7 +38,7 @@ export default function TaxTab({ carId }) {
         })
         .catch(console.error);
     } else {
-      createCarTax({ ...record, CarId: carId })
+      createCarTax(carId, record)
         .then(() => {
           closeModal();
           loadRecords();


### PR DESCRIPTION
## Summary
- align create calls for MOT, service, mileage and tax records with API

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix frontend test` *(fails: react-scripts not found)*
- `npm --prefix backend test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d6a2aef10832e88436ba0616425fe