### PR TITLE
Fix car details endpoint query

### DIFF
--- a/backend/src/routes/carRoutes.js
+++ b/backend/src/routes/carRoutes.js
@@ -36,10 +36,30 @@ router.get('/:id/full', async (req, res) => {
     const carId = req.params.id;
     const car = await Car.findByPk(carId, {
       include: [
-        { model: CarTax, limit: 1, order: [['expiryDate', 'DESC']] },
-        { model: Insurance, limit: 1, order: [['expiryDate', 'DESC']] },
-        { model: ServiceRecord, limit: 1, order: [['serviceDate', 'DESC']] },
-        { model: MileageRecord, limit: 1, order: [['recordDate', 'DESC']] }
+        {
+          model: CarTax,
+          separate: true,
+          limit: 1,
+          order: [['expiryDate', 'DESC']]
+        },
+        {
+          model: Insurance,
+          separate: true,
+          limit: 1,
+          order: [['expiryDate', 'DESC']]
+        },
+        {
+          model: ServiceRecord,
+          separate: true,
+          limit: 1,
+          order: [['serviceDate', 'DESC']]
+        },
+        {
+          model: MileageRecord,
+          separate: true,
+          limit: 1,
+          order: [['recordDate', 'DESC']]
+        }
       ]
     });
 


### PR DESCRIPTION
## Summary
- adjust the `/api/cars/:id/full` query to use `separate: true` with limit

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6efba6f0832e8ee78995205ac1d4