### PR TITLE
Fix renewal date info on car views

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -515,7 +515,7 @@ router.delete('/service-records/:id', async (req, res) => {
 });
 
 // CarTax for a Car
-router.get('/cars/:carId/cartaxes', async (req, res) => {
+router.get('/cars/:carId/car-taxes', async (req, res) => {
   try {
     const taxes = await CarTax.findAll({ where: { CarId: req.params.carId } });
     res.json(taxes);
@@ -524,7 +524,7 @@ router.get('/cars/:carId/cartaxes', async (req, res) => {
   }
 });
 
-router.post('/cars/:carId/cartaxes', async (req, res) => {
+router.post('/cars/:carId/car-taxes', async (req, res) => {
   try {
     const tax = await CarTax.create({ ...req.body, CarId: req.params.carId });
     res.status(201).json(tax);
@@ -533,7 +533,7 @@ router.post('/cars/:carId/cartaxes', async (req, res) => {
   }
 });
 
-router.put('/cartaxes/:id', async (req, res) => {
+router.put('/car-taxes/:id', async (req, res) => {
   try {
     const [updated] = await CarTax.update(req.body, { where: { id: req.params.id } });
     if (!updated) return res.status(404).json({ error: 'CarTax record not found' });
@@ -543,7 +543,7 @@ router.put('/cartaxes/:id', async (req, res) => {
   }
 });
 
-router.delete('/cartaxes/:id', async (req, res) => {
+router.delete('/car-taxes/:id', async (req, res) => {
   try {
     const deleted = await CarTax.destroy({ where: { id: req.params.id } });
     if (!deleted) return res.status(404).json({ error: 'CarTax record not found' });

--- a/frontend/src/modules/carManager/carList.js
+++ b/frontend/src/modules/carManager/carList.js
@@ -33,10 +33,30 @@ export default function CarList({ cars, onSelectCar, selectedCarId }) {
                   {car.make} {car.model} ({car.registration || '-'})
                 </div>
                 <div style={{ fontSize: '0.9rem', marginTop: '0.3rem', display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
-                  <div><strong>Tax Due:</strong> {car.nextTaxDue || '-'}</div>
-                  <div><strong>Insurance Due:</strong> {car.nextInsuranceDue || '-'}</div>
-                  <div><strong>MOT Due:</strong> {car.nextMotDue || '-'}</div>
-                  <div><strong>Service Due:</strong> {car.nextServiceDue || '-'}</div>
+                  <div>
+                    <strong>Tax Due:</strong>{' '}
+                    {car.nextTaxDue
+                      ? new Date(car.nextTaxDue).toLocaleDateString()
+                      : 'No Data Available'}
+                  </div>
+                  <div>
+                    <strong>Insurance Due:</strong>{' '}
+                    {car.nextInsuranceDue
+                      ? new Date(car.nextInsuranceDue).toLocaleDateString()
+                      : 'No Data Available'}
+                  </div>
+                  <div>
+                    <strong>MOT Due:</strong>{' '}
+                    {car.nextMotDue
+                      ? new Date(car.nextMotDue).toLocaleDateString()
+                      : 'No Data Available'}
+                  </div>
+                  <div>
+                    <strong>Service Due:</strong>{' '}
+                    {car.nextServiceDue
+                      ? new Date(car.nextServiceDue).toLocaleDateString()
+                      : 'No Data Available'}
+                  </div>
                 </div>
               </div>
               <button

--- a/frontend/src/modules/carManager/tabs/OverviewTab.js
+++ b/frontend/src/modules/carManager/tabs/OverviewTab.js
@@ -1,12 +1,18 @@
 export default function OverviewTab({ car }) {
   if (!car) return null;
 
-  const nextTaxDue = car.nextTaxDue ? new Date(car.nextTaxDue).toLocaleDateString() : '-';
-  const insuranceRenewal = car.nextInsuranceDue ? new Date(car.nextInsuranceDue).toLocaleDateString() : '-';
-  const insuranceProvider = car.insuranceProviderName || '-';
-  const serviceDueDate = car.nextServiceDue ? new Date(car.nextServiceDue).toLocaleDateString() : '-';
-  const serviceType = car.serviceType || '-';
-  const lastMileage = car.lastMileage || '-';
+  const nextTaxDue = car.nextTaxDue
+    ? new Date(car.nextTaxDue).toLocaleDateString()
+    : 'No Data Available';
+  const insuranceRenewal = car.nextInsuranceDue
+    ? new Date(car.nextInsuranceDue).toLocaleDateString()
+    : 'No Data Available';
+  const insuranceProvider = car.insuranceProviderName || 'No Data Available';
+  const serviceDueDate = car.nextServiceDue
+    ? new Date(car.nextServiceDue).toLocaleDateString()
+    : 'No Data Available';
+  const serviceType = car.serviceType || 'No Data Available';
+  const lastMileage = car.lastMileage || 'No Data Available';
 
   return (
     <div className="modal-content p-2 mb-2" style={{ maxWidth: 'none' }}>


### PR DESCRIPTION
## Summary
- fix CarTax API routes names
- show `No Data Available` placeholders and format renewal dates on car list
- show `No Data Available` placeholders and format dates in overview tab

## Testing
- `npm --prefix frontend test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d784907f4832eb08ae6aa1a3753ec