### PR TITLE
Update car management logic

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -328,13 +328,20 @@ async function addCarSummaryData(car) {
       return d;
     };
 
+    const nextServiceType = service
+      ? service.serviceType === 'Full'
+        ? 'Partial'
+        : 'Full'
+      : null;
+
     Object.assign(result, {
       nextTaxDue: tax ? tax.expiryDate : null,
-      nextInsuranceDue: insurance ? addOneYear(insurance.expiryDate) : null,
-      insuranceProviderName: insurance && insurance.Vendor ? insurance.Vendor.name : null,
+      nextInsuranceDue: insurance ? insurance.expiryDate : null,
+      insuranceProviderName:
+        insurance && insurance.Vendor ? insurance.Vendor.name : null,
       nextMotDue: mot ? mot.expiryDate : null,
       nextServiceDue: service ? addOneYear(service.serviceDate) : null,
-      serviceType: service ? service.serviceType : null,
+      serviceType: nextServiceType,
       lastMileage: mileage ? mileage.mileage : null,
     });
   } catch (err) {

--- a/frontend/src/modules/carManager/carDetails.js
+++ b/frontend/src/modules/carManager/carDetails.js
@@ -4,6 +4,7 @@ import OverviewTab from './tabs/OverviewTab';
 import MotTab from './tabs/MotTab';
 import InsuranceTab from './tabs/InsuranceTab';
 import ServiceTab from './tabs/ServiceTab';
+import TaxTab from './tabs/TaxTab';
 import MileageTab from './tabs/MileageTab';
 
 export default function CarDetails({ carId, onClose, onCarsUpdated }) {
@@ -35,6 +36,8 @@ export default function CarDetails({ carId, onClose, onCarsUpdated }) {
         return <InsuranceTab carId={carId} onChange={handleRecordsChange} />;
       case 'service':
         return <ServiceTab carId={carId} onChange={handleRecordsChange} />;
+      case 'tax':
+        return <TaxTab carId={carId} onChange={handleRecordsChange} />;
       case 'mileage':
         return <MileageTab carId={carId} onChange={handleRecordsChange} />;
       default:
@@ -55,7 +58,7 @@ export default function CarDetails({ carId, onClose, onCarsUpdated }) {
         {/* Tabs navigation without overview */}
         <div style={styles.tabs}>
           <nav style={styles.nav}>
-            {['mot', 'insurance', 'service', 'mileage'].map(tab => (
+            {['mot', 'insurance', 'service', 'tax', 'mileage'].map(tab => (
               <button
                 key={tab}
                 style={{ 

--- a/frontend/src/modules/carManager/carList.js
+++ b/frontend/src/modules/carManager/carList.js
@@ -36,25 +36,25 @@ export default function CarList({ cars, onSelectCar, selectedCarId }) {
                   <div>
                     <strong>Tax Due:</strong>{' '}
                     {car.nextTaxDue
-                      ? new Date(car.nextTaxDue).toLocaleDateString()
+                      ? new Date(car.nextTaxDue).toLocaleDateString('en-GB')
                       : 'No Data Available'}
                   </div>
                   <div>
                     <strong>Insurance Due:</strong>{' '}
                     {car.nextInsuranceDue
-                      ? new Date(car.nextInsuranceDue).toLocaleDateString()
+                      ? new Date(car.nextInsuranceDue).toLocaleDateString('en-GB')
                       : 'No Data Available'}
                   </div>
                   <div>
                     <strong>MOT Due:</strong>{' '}
                     {car.nextMotDue
-                      ? new Date(car.nextMotDue).toLocaleDateString()
+                      ? new Date(car.nextMotDue).toLocaleDateString('en-GB')
                       : 'No Data Available'}
                   </div>
                   <div>
                     <strong>Service Due:</strong>{' '}
                     {car.nextServiceDue
-                      ? new Date(car.nextServiceDue).toLocaleDateString()
+                      ? new Date(car.nextServiceDue).toLocaleDateString('en-GB')
                       : 'No Data Available'}
                   </div>
                 </div>

--- a/frontend/src/modules/carManager/tabs/InsuranceTab.js
+++ b/frontend/src/modules/carManager/tabs/InsuranceTab.js
@@ -100,7 +100,7 @@ export default function InsuranceTab({ carId, onChange }) {
                 <tr key={rec.id}>
                   <td>{vendor ? vendor.name : 'Unknown'}</td>
                   <td>{rec.policyNumber}</td>
-                  <td>{new Date(rec.expiryDate).toLocaleDateString()}</td>
+                  <td>{new Date(rec.expiryDate).toLocaleDateString('en-GB')}</td>
                   <td>{rec.cost}</td>
                   <td>{rec.notes || '-'}</td>
                   <td>

--- a/frontend/src/modules/carManager/tabs/MileageTab.js
+++ b/frontend/src/modules/carManager/tabs/MileageTab.js
@@ -78,7 +78,7 @@ export default function MileageTab({ carId, onChange }) {
           <tbody>
             {records.map(rec => (
               <tr key={rec.id}>
-                <td>{new Date(rec.recordDate).toLocaleDateString()}</td>
+                <td>{new Date(rec.recordDate).toLocaleDateString('en-GB')}</td>
                 <td>{rec.mileage}</td>
                 <td>
                   <button className="btn btn-sm btn-secondary me-2" onClick={() => openEdit(rec)}>Edit</button>

--- a/frontend/src/modules/carManager/tabs/MotTab.js
+++ b/frontend/src/modules/carManager/tabs/MotTab.js
@@ -80,8 +80,8 @@ export default function MotTab({ carId, onChange }) {
           <tbody>
             {records.map(rec => (
               <tr key={rec.id}>
-                <td>{new Date(rec.testDate).toLocaleDateString()}</td>
-                <td>{new Date(rec.expiryDate).toLocaleDateString()}</td>
+                <td>{new Date(rec.testDate).toLocaleDateString('en-GB')}</td>
+                <td>{new Date(rec.expiryDate).toLocaleDateString('en-GB')}</td>
                 <td>{rec.cost}</td>
                 <td>{rec.notes || '-'}</td>
                 <td>

--- a/frontend/src/modules/carManager/tabs/OverviewTab.js
+++ b/frontend/src/modules/carManager/tabs/OverviewTab.js
@@ -2,14 +2,17 @@ export default function OverviewTab({ car }) {
   if (!car) return null;
 
   const nextTaxDue = car.nextTaxDue
-    ? new Date(car.nextTaxDue).toLocaleDateString()
+    ? new Date(car.nextTaxDue).toLocaleDateString('en-GB')
     : 'No Data Available';
   const insuranceRenewal = car.nextInsuranceDue
-    ? new Date(car.nextInsuranceDue).toLocaleDateString()
+    ? new Date(car.nextInsuranceDue).toLocaleDateString('en-GB')
+    : 'No Data Available';
+  const nextMotDue = car.nextMotDue
+    ? new Date(car.nextMotDue).toLocaleDateString('en-GB')
     : 'No Data Available';
   const insuranceProvider = car.insuranceProviderName || 'No Data Available';
   const serviceDueDate = car.nextServiceDue
-    ? new Date(car.nextServiceDue).toLocaleDateString()
+    ? new Date(car.nextServiceDue).toLocaleDateString('en-GB')
     : 'No Data Available';
   const serviceType = car.serviceType || 'No Data Available';
   const lastMileage = car.lastMileage || 'No Data Available';
@@ -20,6 +23,7 @@ export default function OverviewTab({ car }) {
       <p><strong>Next Tax Due:</strong> {nextTaxDue}</p>
       <p><strong>Insurance Renewal:</strong> {insuranceRenewal}</p>
       <p><strong>Insurance Provider:</strong> {insuranceProvider}</p>
+      <p><strong>Next MOT Due:</strong> {nextMotDue}</p>
       <p><strong>Service Due Date:</strong> {serviceDueDate}</p>
       <p><strong>Next Service Type:</strong> {serviceType}</p>
       <p><strong>Last Recorded Mileage:</strong> {lastMileage}</p>

--- a/frontend/src/modules/carManager/tabs/ServiceTab.js
+++ b/frontend/src/modules/carManager/tabs/ServiceTab.js
@@ -81,7 +81,7 @@ export default function ServiceTab({ carId, onChange }) {
           <tbody>
             {records.map(rec => (
               <tr key={rec.id}>
-                <td>{new Date(rec.serviceDate).toLocaleDateString()}</td>
+                <td>{new Date(rec.serviceDate).toLocaleDateString('en-GB')}</td>
                 <td>{rec.mileage || '-'}</td>
                 <td>{rec.serviceType}</td>
                 <td>{rec.cost || '-'}</td>

--- a/frontend/src/modules/carManager/tabs/TaxTab.js
+++ b/frontend/src/modules/carManager/tabs/TaxTab.js
@@ -79,7 +79,7 @@ export default function TaxTab({ carId, onChange }) {
           <tbody>
             {records.map(rec => (
               <tr key={rec.id}>
-                <td>{new Date(rec.expiryDate).toLocaleDateString()}</td>
+                <td>{new Date(rec.expiryDate).toLocaleDateString('en-GB')}</td>
                 <td>{rec.cost}</td>
                 <td>{rec.notes || '-'}</td>
                 <td>


### PR DESCRIPTION
## Summary
- update car summary logic
- add tax tab to car details
- display next MOT due date in overview
- show next service type opposite of last
- use UK-style dates in car modules

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d911146b8832e9868dd81d85ae335