### PR TITLE
Fix inline style clash on car details tabs

### DIFF
--- a/frontend/src/modules/carManager/carDetails.js
+++ b/frontend/src/modules/carManager/carDetails.js
@@ -136,7 +136,9 @@ const styles = {
     padding: '1rem 1.5rem',
     cursor: 'pointer',
     fontSize: '1rem',
-    borderBottom: '3px solid transparent',
+    borderBottomWidth: '3px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: 'transparent',
   },
   activeTabBtn: {
     borderBottomColor: '#007bff',


### PR DESCRIPTION
## Summary
- resolve React warning about conflicting tab button styles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9553696c832ea254767e76993538