### PR TITLE
Enhance car overview

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,8 @@
   --accent:         #1e90ff;
   --danger:         #d32f2f;
   --warning:        #f9a825;
+  --success:        #4caf50;
+  --caution:        #ffb300;
   --text-light:     #f1f5f9;
   --bg:             #0a182e;
   /* Table-specific */
@@ -210,3 +212,29 @@ input:focus, select:focus, textarea:focus {
   border-bottom: 2px solid var(--accent);
   padding-bottom: 0.25rem;
 }
+
+/* Dashboard Overview */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.pill {
+  background: var(--blue-dark);
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.pill span {
+  font-size: 0.9rem;
+}
+
+.pill.green  { background: var(--success); color: var(--bg); }
+.pill.yellow { background: var(--warning); color: var(--blue-dark); }
+.pill.amber  { background: var(--caution); color: var(--blue-dark); }
+.pill.red    { background: var(--danger); color: #fff; }

--- a/frontend/src/modules/carManager/tabs/OverviewTab.js
+++ b/frontend/src/modules/carManager/tabs/OverviewTab.js
@@ -1,32 +1,58 @@
 export default function OverviewTab({ car }) {
   if (!car) return null;
 
-  const nextTaxDue = car.nextTaxDue
-    ? new Date(car.nextTaxDue).toLocaleDateString('en-GB')
-    : 'No Data Available';
-  const insuranceRenewal = car.nextInsuranceDue
-    ? new Date(car.nextInsuranceDue).toLocaleDateString('en-GB')
-    : 'No Data Available';
-  const nextMotDue = car.nextMotDue
-    ? new Date(car.nextMotDue).toLocaleDateString('en-GB')
-    : 'No Data Available';
+  const formatDate = (date) =>
+    date ? new Date(date).toLocaleDateString('en-GB') : 'No Data Available';
+
+  const getStatusClass = (date) => {
+    if (!date) return 'pill';
+    const today = new Date();
+    const target = new Date(date);
+    const diffDays = (target - today) / (1000 * 60 * 60 * 24);
+
+    if (diffDays > 183) return 'pill green';      // > 6 months
+    if (diffDays > 90)  return 'pill yellow';     // 6 - 3 months
+    if (diffDays > 30)  return 'pill amber';      // 3 - 1 month
+    return 'pill red';                            // < 1 month or past
+  };
+
   const insuranceProvider = car.insuranceProviderName || 'No Data Available';
-  const serviceDueDate = car.nextServiceDue
-    ? new Date(car.nextServiceDue).toLocaleDateString('en-GB')
-    : 'No Data Available';
   const serviceType = car.serviceType || 'No Data Available';
   const lastMileage = car.lastMileage || 'No Data Available';
 
   return (
     <div className="modal-content p-2 mb-2" style={{ maxWidth: 'none' }}>
       <h2>{car.make} {car.model} ({car.registration})</h2>
-      <p><strong>Next Tax Due:</strong> {nextTaxDue}</p>
-      <p><strong>Insurance Renewal:</strong> {insuranceRenewal}</p>
-      <p><strong>Insurance Provider:</strong> {insuranceProvider}</p>
-      <p><strong>Next MOT Due:</strong> {nextMotDue}</p>
-      <p><strong>Service Due Date:</strong> {serviceDueDate}</p>
-      <p><strong>Next Service Type:</strong> {serviceType}</p>
-      <p><strong>Last Recorded Mileage:</strong> {lastMileage}</p>
+      <div className="dashboard-grid">
+        <div className={getStatusClass(car.nextTaxDue)}>
+          <strong>Next Tax Due</strong>
+          <span>{formatDate(car.nextTaxDue)}</span>
+        </div>
+        <div className={getStatusClass(car.nextInsuranceDue)}>
+          <strong>Insurance Renewal</strong>
+          <span>{formatDate(car.nextInsuranceDue)}</span>
+        </div>
+        <div className="pill">
+          <strong>Insurance Provider</strong>
+          <span>{insuranceProvider}</span>
+        </div>
+        <div className={getStatusClass(car.nextMotDue)}>
+          <strong>Next MOT Due</strong>
+          <span>{formatDate(car.nextMotDue)}</span>
+        </div>
+        <div className={getStatusClass(car.nextServiceDue)}>
+          <strong>Service Due Date</strong>
+          <span>{formatDate(car.nextServiceDue)}</span>
+        </div>
+        <div className="pill">
+          <strong>Next Service Type</strong>
+          <span>{serviceType}</span>
+        </div>
+        <div className="pill">
+          <strong>Last Recorded Mileage</strong>
+          <span>{lastMileage}</span>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- style car overview as a dashboard with two columns
- show overview info inside pill elements
- color code renewal dates by how soon they are due
- add dashboard and pill styles to global CSS

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm --prefix backend test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d971a4c8c832e981f123c80856e11