### PR TITLE
Add car deletion and retirement support

### DIFF
--- a/backend/migrations/20250615-add-car-status.js
+++ b/backend/migrations/20250615-add-car-status.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Cars', 'status', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      defaultValue: 'Active'
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Cars', 'status');
+  }
+};

--- a/backend/src/models/Car.js
+++ b/backend/src/models/Car.js
@@ -8,6 +8,11 @@ const Car = sequelize.define('Car', {
   registration: { type: DataTypes.STRING, unique: true },
   value:      { type: DataTypes.DECIMAL(10, 2) },
   notes:      { type: DataTypes.TEXT },
+  status:     {
+    type: DataTypes.STRING,
+    allowNull: false,
+    defaultValue: 'Active'
+  },
 });
 
 module.exports = Car;

--- a/frontend/src/modules/carManager/carDetails.js
+++ b/frontend/src/modules/carManager/carDetails.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { getCar } from '../../api';
+import { getCar, deleteCar, updateCar } from '../../api';
 import OverviewTab from './tabs/OverviewTab';
 import MotTab from './tabs/MotTab';
 import InsuranceTab from './tabs/InsuranceTab';
@@ -28,6 +28,27 @@ export default function CarDetails({ carId, onClose, onCarsUpdated }) {
     if (onCarsUpdated) onCarsUpdated();
   };
 
+  const handleDelete = () => {
+    if (window.confirm('Delete this car?')) {
+      deleteCar(carId)
+        .then(() => {
+          if (onCarsUpdated) onCarsUpdated();
+          onClose();
+        })
+        .catch(console.error);
+    }
+  };
+
+  const handleToggleStatus = () => {
+    const newStatus = car.status === 'Retired' ? 'Active' : 'Retired';
+    updateCar(carId, { status: newStatus })
+      .then(() => {
+        loadCar();
+        if (onCarsUpdated) onCarsUpdated();
+      })
+      .catch(console.error);
+  };
+
   const renderTabContent = () => {
     switch (activeTab) {
       case 'mot':
@@ -49,6 +70,12 @@ export default function CarDetails({ carId, onClose, onCarsUpdated }) {
     <div style={styles.overlay}>
       <div style={styles.container}>
         <button onClick={onClose} style={styles.closeBtn}>×</button>
+        <div style={styles.actionBar}>
+          <button className="btn btn-danger btn-sm" onClick={handleDelete}>Delete</button>
+          <button className="btn btn-warning btn-sm" onClick={handleToggleStatus}>
+            {car.status === 'Retired' ? 'Activate' : 'Retire'}
+          </button>
+        </div>
 
         {/* Always visible Overview */}
         <div style={styles.overview}>
@@ -111,6 +138,11 @@ const styles = {
     background: 'none',
     border: 'none',
     cursor: 'pointer',
+  },
+  actionBar: {
+    display: 'flex',
+    gap: '0.5rem',
+    padding: '0.5rem 1rem',
   },
   overview: {
     flexShrink: 0,

--- a/frontend/src/modules/carManager/carList.js
+++ b/frontend/src/modules/carManager/carList.js
@@ -9,6 +9,7 @@ export default function CarList({ cars, onSelectCar, selectedCarId }) {
       ) : (
         cars.map(car => {
           const isSelected = car.id === selectedCarId;
+          const isRetired = car.status === 'Retired';
           return (
             <div
               key={car.id}
@@ -24,6 +25,7 @@ export default function CarList({ cars, onSelectCar, selectedCarId }) {
                 color: 'var(--text-light)',
                 boxShadow: isSelected ? '0 0 10px var(--accent)' : 'none',
                 transition: 'background-color 0.3s ease',
+                opacity: isRetired ? 0.5 : 1,
               }}
               onMouseEnter={e => e.currentTarget.style.backgroundColor = isSelected ? 'var(--blue-mid)' : 'var(--blue-light)'}
               onMouseLeave={e => e.currentTarget.style.backgroundColor = isSelected ? 'var(--blue-mid)' : 'var(--blue-dark)'}
@@ -31,6 +33,9 @@ export default function CarList({ cars, onSelectCar, selectedCarId }) {
               <div>
                 <div style={{ fontWeight: 'bold', fontSize: '1.2rem' }}>
                   {car.make} {car.model} ({car.registration || '-'})
+                </div>
+                <div style={{ fontSize: '0.8rem', marginTop: '0.25rem' }}>
+                  Status: {car.status || 'Active'}
                 </div>
                 <div style={{ fontSize: '0.9rem', marginTop: '0.3rem', display: 'flex', gap: '1.5rem', flexWrap: 'wrap' }}>
                   <div>


### PR DESCRIPTION
## Summary
- add `status` field to `Cars`
- support toggling retirement and deleting cars in UI
- show car status in list and grey out retired cars
- migration for new car status field

## Testing
- `npm test --prefix frontend --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9923eb98832e829338d0790a2963