### PR TITLE
Fix action button layout for contract tables

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,6 +93,20 @@ table {
   border-collapse: collapse;
   margin-bottom: 1rem;
 }
+/* Keep column widths consistent */
+.fixed-table {
+  table-layout: fixed;
+}
+.fixed-table th,
+.fixed-table td {
+  word-wrap: break-word;
+}
+/* Stack action buttons vertically */
+.action-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
 thead {
   background: var(--table-header);
 }

--- a/frontend/src/modules/contractManager/categoryList.js
+++ b/frontend/src/modules/contractManager/categoryList.js
@@ -80,7 +80,7 @@ export default function CategoryList() {
         </button>
       </div>
 
-      <table>
+      <table className="fixed-table">
         <thead>
           <tr>
             <th>Name</th>
@@ -96,19 +96,20 @@ export default function CategoryList() {
               <td>Category</td>
               <td>—</td>
               <td>
-                <button
-                  onClick={() => openEditCategory(c)}
-                  className="btn btn-warning btn-sm"
-                  style={{ marginRight: '0.5rem' }}
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => deleteCategoryById(c.id)}
-                  className="btn btn-danger btn-sm"
-                >
-                  Delete
-                </button>
+                <div className="action-buttons">
+                  <button
+                    onClick={() => openEditCategory(c)}
+                    className="btn btn-warning btn-sm"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteCategoryById(c.id)}
+                    className="btn btn-danger btn-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
               </td>
             </tr>
           ))}
@@ -119,19 +120,20 @@ export default function CategoryList() {
               <td>Subcategory</td>
               <td>{sc.Category?.name || '—'}</td>
               <td>
-                <button
-                  onClick={() => openEditSubcategory(sc)}
-                  className="btn btn-warning btn-sm"
-                  style={{ marginRight: '0.5rem' }}
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => deleteSubcategoryById(sc.id)}
-                  className="btn btn-danger btn-sm"
-                >
-                  Delete
-                </button>
+                <div className="action-buttons">
+                  <button
+                    onClick={() => openEditSubcategory(sc)}
+                    className="btn btn-warning btn-sm"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => deleteSubcategoryById(sc.id)}
+                    className="btn btn-danger btn-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/frontend/src/modules/contractManager/contractList.js
+++ b/frontend/src/modules/contractManager/contractList.js
@@ -34,7 +34,7 @@ export default function ContractList() {
         New Service
       </button>
 
-      <table>
+      <table className="fixed-table">
         <thead>
           <tr>
             <th>Name</th>
@@ -58,18 +58,20 @@ export default function ContractList() {
               <td>{new Date(c.next_due_date).toLocaleDateString('en-GB')}</td>
               <td>{c.notes}</td>
               <td>
-                <button
-                  onClick={() => openEdit(c)}
-                  className="btn btn-warning btn-sm"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => handleDelete(c.id)}
-                  className="btn btn-danger btn-sm"
-                >
-                  Delete
-                </button>
+                <div className="action-buttons">
+                  <button
+                    onClick={() => openEdit(c)}
+                    className="btn btn-warning btn-sm"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(c.id)}
+                    className="btn btn-danger btn-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/frontend/src/modules/contractManager/vendorList.js
+++ b/frontend/src/modules/contractManager/vendorList.js
@@ -72,7 +72,7 @@ export default function VendorList() {
         New Vendor
       </button>
 
-      <table>
+      <table className="fixed-table">
         <thead>
           <tr>
             <th>Name</th>
@@ -88,18 +88,20 @@ export default function VendorList() {
               <td>{v.contact_info}</td>
               <td>{v.notes}</td>
               <td>
-                <button
-                  onClick={() => openEdit(v)}
-                  className="btn btn-warning btn-sm"
-                >
-                  Edit
-                </button>{' '}
-                <button
-                  onClick={() => handleDelete(v.id)}
-                  className="btn btn-danger btn-sm"
-                >
-                  Delete
-                </button>
+                <div className="action-buttons">
+                  <button
+                    onClick={() => openEdit(v)}
+                    className="btn btn-warning btn-sm"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(v.id)}
+                    className="btn btn-danger btn-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- keep table columns fixed width and wrap long text
- stack Edit/Delete buttons vertically for service, vendor and category lists

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9f8632a8832e911a84c040262fd7