### PR TITLE
Unify action column sizing

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,6 +107,14 @@ table {
   flex-direction: column;
   gap: 0.25rem;
 }
+/* Consistent width for actions column */
+.actions-col {
+  width: 120px;
+}
+/* Make action buttons equal width */
+.action-buttons .btn {
+  width: 80px;
+}
 thead {
   background: var(--table-header);
 }

--- a/frontend/src/modules/contractManager/categoryList.js
+++ b/frontend/src/modules/contractManager/categoryList.js
@@ -86,7 +86,7 @@ export default function CategoryList() {
             <th>Name</th>
             <th>Type</th>
             <th>Parent Category</th>
-            <th>Actions</th>
+            <th className="actions-col">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -95,7 +95,7 @@ export default function CategoryList() {
               <td>{c.name}</td>
               <td>Category</td>
               <td>—</td>
-              <td>
+              <td className="actions-col">
                 <div className="action-buttons">
                   <button
                     onClick={() => openEditCategory(c)}
@@ -119,7 +119,7 @@ export default function CategoryList() {
               <td>{sc.name}</td>
               <td>Subcategory</td>
               <td>{sc.Category?.name || '—'}</td>
-              <td>
+              <td className="actions-col">
                 <div className="action-buttons">
                   <button
                     onClick={() => openEditSubcategory(sc)}

--- a/frontend/src/modules/contractManager/contractList.js
+++ b/frontend/src/modules/contractManager/contractList.js
@@ -44,7 +44,7 @@ export default function ContractList() {
             <th>Start Date</th>
             <th>Next Due</th>
             <th>Notes</th>
-            <th>Actions</th>
+            <th className="actions-col">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -57,7 +57,7 @@ export default function ContractList() {
               <td>{new Date(c.start_date).toLocaleDateString('en-GB')}</td>
               <td>{new Date(c.next_due_date).toLocaleDateString('en-GB')}</td>
               <td>{c.notes}</td>
-              <td>
+              <td className="actions-col">
                 <div className="action-buttons">
                   <button
                     onClick={() => openEdit(c)}

--- a/frontend/src/modules/contractManager/frequencyList.js
+++ b/frontend/src/modules/contractManager/frequencyList.js
@@ -51,12 +51,12 @@ export default function FrequencyList() {
         New Frequency
       </button>
 
-      <table className="table-auto w-full">
+      <table className="fixed-table">
         <thead>
           <tr>
             <th className="px-4 py-2">Name</th>
             <th className="px-4 py-2">Interval Months</th>
-            <th className="px-4 py-2">Actions</th>
+            <th className="actions-col px-4 py-2">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -64,19 +64,21 @@ export default function FrequencyList() {
             <tr key={f.id}>
               <td className="border px-4 py-2">{f.name}</td>
               <td className="border px-4 py-2">{f.interval_months}</td>
-              <td className="border px-4 py-2">
-                <button
-                  onClick={() => openEdit(f)}
-                  className="btn btn-warning btn-sm mr-2"
-                >
-                  Edit
-                </button>
-                <button
-                  onClick={() => handleDelete(f.id)}
-                  className="btn btn-danger btn-sm"
-                >
-                  Delete
-                </button>
+              <td className="actions-col border px-4 py-2">
+                <div className="action-buttons">
+                  <button
+                    onClick={() => openEdit(f)}
+                    className="btn btn-warning btn-sm"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(f.id)}
+                    className="btn btn-danger btn-sm"
+                  >
+                    Delete
+                  </button>
+                </div>
               </td>
             </tr>
           ))}

--- a/frontend/src/modules/contractManager/vendorList.js
+++ b/frontend/src/modules/contractManager/vendorList.js
@@ -78,7 +78,7 @@ export default function VendorList() {
             <th>Name</th>
             <th>Contact Info</th>
             <th>Notes</th>
-            <th>Actions</th>
+            <th className="actions-col">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -87,7 +87,7 @@ export default function VendorList() {
               <td>{v.name}</td>
               <td>{v.contact_info}</td>
               <td>{v.notes}</td>
-              <td>
+              <td className="actions-col">
                 <div className="action-buttons">
                   <button
                     onClick={() => openEdit(v)}


### PR DESCRIPTION
## Summary
- set consistent width for action column
- give action buttons equal width
- make frequency list match other tables

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da109d29c832ebbe85155615b6f7b