### PR TITLE
Implement budgeting module

### DIFF
--- a/backend/migrations/20250620-create-budgeting-module.js
+++ b/backend/migrations/20250620-create-budgeting-module.js
@@ -1,0 +1,81 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('BudgetMonths', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      month: { type: Sequelize.STRING, allowNull: false, unique: true },
+      notes: Sequelize.TEXT,
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+
+    await queryInterface.createTable('BudgetLines', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      name: { type: Sequelize.STRING, allowNull: false },
+      category: { type: Sequelize.STRING, allowNull: false },
+      planned: { type: Sequelize.DECIMAL(10,2), allowNull: false },
+      actual: { type: Sequelize.DECIMAL(10,2), defaultValue: 0 },
+      is_paid: { type: Sequelize.BOOLEAN, defaultValue: false },
+      is_retired: { type: Sequelize.BOOLEAN, defaultValue: false },
+      repeats_annually: { type: Sequelize.BOOLEAN, defaultValue: false },
+      BudgetMonthId: {
+        type: Sequelize.INTEGER,
+        references: { model: 'BudgetMonths', key: 'id' },
+        onDelete: 'CASCADE',
+        allowNull: false
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+
+    await queryInterface.createTable('IncomeSources', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      name: { type: Sequelize.STRING, allowNull: false },
+      amount: { type: Sequelize.DECIMAL(10,2), allowNull: false },
+      BudgetMonthId: {
+        type: Sequelize.INTEGER,
+        references: { model: 'BudgetMonths', key: 'id' },
+        onDelete: 'CASCADE',
+        allowNull: false
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+
+    await queryInterface.createTable('SavingPots', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      name: { type: Sequelize.STRING, allowNull: false, unique: true },
+      current_value: { type: Sequelize.DECIMAL(10,2), defaultValue: 0 },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+
+    await queryInterface.createTable('SavingEntries', {
+      id: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
+      value: { type: Sequelize.DECIMAL(10,2), allowNull: false },
+      BudgetMonthId: {
+        type: Sequelize.INTEGER,
+        references: { model: 'BudgetMonths', key: 'id' },
+        onDelete: 'CASCADE',
+        allowNull: false
+      },
+      SavingPotId: {
+        type: Sequelize.INTEGER,
+        references: { model: 'SavingPots', key: 'id' },
+        onDelete: 'CASCADE',
+        allowNull: false
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('SavingEntries');
+    await queryInterface.dropTable('SavingPots');
+    await queryInterface.dropTable('IncomeSources');
+    await queryInterface.dropTable('BudgetLines');
+    await queryInterface.dropTable('BudgetMonths');
+  }
+};

--- a/backend/src/models/BudgetLine.js
+++ b/backend/src/models/BudgetLine.js
@@ -1,0 +1,18 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const BudgetMonth = require('./BudgetMonth');
+
+const BudgetLine = sequelize.define('BudgetLine', {
+  name: { type: DataTypes.STRING, allowNull: false },
+  category: { type: DataTypes.STRING, allowNull: false },
+  planned: { type: DataTypes.DECIMAL(10,2), allowNull: false },
+  actual: { type: DataTypes.DECIMAL(10,2), defaultValue: 0 },
+  is_paid: { type: DataTypes.BOOLEAN, defaultValue: false },
+  is_retired: { type: DataTypes.BOOLEAN, defaultValue: false },
+  repeats_annually: { type: DataTypes.BOOLEAN, defaultValue: false },
+});
+
+BudgetLine.belongsTo(BudgetMonth, { foreignKey: { allowNull: false } });
+BudgetMonth.hasMany(BudgetLine);
+
+module.exports = BudgetLine;

--- a/backend/src/models/BudgetMonth.js
+++ b/backend/src/models/BudgetMonth.js
@@ -1,0 +1,9 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const BudgetMonth = sequelize.define('BudgetMonth', {
+  month: { type: DataTypes.STRING, allowNull: false, unique: true },
+  notes: DataTypes.TEXT,
+});
+
+module.exports = BudgetMonth;

--- a/backend/src/models/IncomeSource.js
+++ b/backend/src/models/IncomeSource.js
@@ -1,0 +1,13 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const BudgetMonth = require('./BudgetMonth');
+
+const IncomeSource = sequelize.define('IncomeSource', {
+  name: { type: DataTypes.STRING, allowNull: false },
+  amount: { type: DataTypes.DECIMAL(10,2), allowNull: false },
+});
+
+IncomeSource.belongsTo(BudgetMonth, { foreignKey: { allowNull: false } });
+BudgetMonth.hasMany(IncomeSource);
+
+module.exports = IncomeSource;

--- a/backend/src/models/SavingEntry.js
+++ b/backend/src/models/SavingEntry.js
@@ -1,0 +1,15 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+const BudgetMonth = require('./BudgetMonth');
+const SavingPot = require('./SavingPot');
+
+const SavingEntry = sequelize.define('SavingEntry', {
+  value: { type: DataTypes.DECIMAL(10,2), allowNull: false },
+});
+
+SavingEntry.belongsTo(BudgetMonth, { foreignKey: { allowNull: false } });
+BudgetMonth.hasMany(SavingEntry);
+SavingEntry.belongsTo(SavingPot, { foreignKey: { allowNull: false } });
+SavingPot.hasMany(SavingEntry);
+
+module.exports = SavingEntry;

--- a/backend/src/models/SavingPot.js
+++ b/backend/src/models/SavingPot.js
@@ -1,0 +1,9 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const SavingPot = sequelize.define('SavingPot', {
+  name: { type: DataTypes.STRING, allowNull: false, unique: true },
+  current_value: { type: DataTypes.DECIMAL(10,2), defaultValue: 0 },
+});
+
+module.exports = SavingPot;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -12,6 +12,11 @@ const CarTax       = require('./CarTax');
 const MileageRecord= require('./MileageRecord');
 const BacklogItem  = require('./BacklogItem');
 const BacklogNote  = require('./BacklogNote');
+const BudgetMonth  = require('./BudgetMonth');
+const BudgetLine   = require('./BudgetLine');
+const IncomeSource = require('./IncomeSource');
+const SavingPot    = require('./SavingPot');
+const SavingEntry  = require('./SavingEntry');
 
 // Associations:
 Service.hasMany(Attachment, { foreignKey: 'ServiceId', onDelete: 'CASCADE' });
@@ -46,4 +51,9 @@ module.exports = {
   MileageRecord,
   BacklogItem,
   BacklogNote,
+  BudgetMonth,
+  BudgetLine,
+  IncomeSource,
+  SavingPot,
+  SavingEntry,
 };

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -20,6 +20,11 @@ const CarTax        = require('./models/CarTax');
 const MileageRecord = require('./models/MileageRecord');
 const BacklogItem   = require('./models/BacklogItem');
 const BacklogNote   = require('./models/BacklogNote');
+const BudgetMonth   = require('./models/BudgetMonth');
+const BudgetLine    = require('./models/BudgetLine');
+const IncomeSource  = require('./models/IncomeSource');
+const SavingPot     = require('./models/SavingPot');
+const SavingEntry   = require('./models/SavingEntry');
 
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
@@ -292,6 +297,208 @@ router.get('/backlog-items/:itemId/attachments', async (req, res) => {
   try {
     const attachments = await Attachment.findAll({ where: { BacklogItemId: req.params.itemId } });
     res.json(attachments);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// --------- Budget Months ---------
+router.get('/budget-months', async (req, res) => {
+  try {
+    const months = await BudgetMonth.findAll();
+    res.json(months);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/budget-months', async (req, res) => {
+  try {
+    const month = await BudgetMonth.create(req.body);
+    res.status(201).json(month);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/budget-months/:id', async (req, res) => {
+  try {
+    const [updated] = await BudgetMonth.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/budget-months/:id', async (req, res) => {
+  try {
+    const deleted = await BudgetMonth.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/budget-months/:id/copy', async (req, res) => {
+  try {
+    const fromId = req.body.fromId;
+    const lines = await BudgetLine.findAll({ where: { BudgetMonthId: fromId, category: ['Bill','Variable'] } });
+    const created = await Promise.all(lines.map(l => {
+      const data = { ...l.toJSON(), id: undefined, is_paid: false, BudgetMonthId: req.params.id };
+      return BudgetLine.create(data);
+    }));
+    res.json(created);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.get('/budget-months/:monthId/lines', async (req, res) => {
+  try {
+    const lines = await BudgetLine.findAll({ where: { BudgetMonthId: req.params.monthId } });
+    res.json(lines);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/budget-months/:monthId/lines', async (req, res) => {
+  try {
+    const line = await BudgetLine.create({ ...req.body, BudgetMonthId: req.params.monthId });
+    res.status(201).json(line);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/budget-lines/:id', async (req, res) => {
+  try {
+    const [updated] = await BudgetLine.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/budget-lines/:id', async (req, res) => {
+  try {
+    const deleted = await BudgetLine.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/budget-months/:monthId/incomes', async (req, res) => {
+  try {
+    const incomes = await IncomeSource.findAll({ where: { BudgetMonthId: req.params.monthId } });
+    res.json(incomes);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/budget-months/:monthId/incomes', async (req, res) => {
+  try {
+    const inc = await IncomeSource.create({ ...req.body, BudgetMonthId: req.params.monthId });
+    res.status(201).json(inc);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/income-sources/:id', async (req, res) => {
+  try {
+    const [updated] = await IncomeSource.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/income-sources/:id', async (req, res) => {
+  try {
+    const deleted = await IncomeSource.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Saving pots
+router.get('/saving-pots', async (req, res) => {
+  try { res.json(await SavingPot.findAll()); }
+  catch (err) { res.status(500).json({ error: err.message }); }
+});
+
+router.post('/saving-pots', async (req, res) => {
+  try {
+    const pot = await SavingPot.create(req.body);
+    res.status(201).json(pot);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/saving-pots/:id', async (req, res) => {
+  try {
+    const [updated] = await SavingPot.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/saving-pots/:id', async (req, res) => {
+  try {
+    const deleted = await SavingPot.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/saving-pots/:potId/entries', async (req, res) => {
+  try {
+    const entries = await SavingEntry.findAll({ where: { SavingPotId: req.params.potId }, order: [['createdAt','ASC']] });
+    res.json(entries);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/saving-pots/:potId/entries', async (req, res) => {
+  try {
+    const entry = await SavingEntry.create({ ...req.body, SavingPotId: req.params.potId });
+    res.status(201).json(entry);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/saving-entries/:id', async (req, res) => {
+  try {
+    const [updated] = await SavingEntry.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/saving-entries/:id', async (req, res) => {
+  try {
+    const deleted = await SavingEntry.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,6 +16,11 @@ require('./models/user');
 require('./models/Attachment'); // Make sure to require this!
 require('./models/BacklogItem');
 require('./models/BacklogNote');
+require('./models/BudgetMonth');
+require('./models/BudgetLine');
+require('./models/IncomeSource');
+require('./models/SavingPot');
+require('./models/SavingEntry');
 
 const app = express();
 const PORT = process.env.PORT || 4000;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import HomePage from './components/home/homePage';
 import ContractManager from './modules/contractManager/contractManager';
 import CarManager from './modules/carManager/carManager';  // new
 import BacklogManager from './modules/backlogManager/backlogManager';
+import BudgetManager from './modules/budgetManager/budgetManager';
 import UserManager from './modules/userManager/userManager';
 import ThemeToggle from './components/ui/ThemeToggle';
 
@@ -33,6 +34,12 @@ function NavTabs() {
         className={pathname.startsWith('/cars') ? 'active' : ''}
       >
         Car Management
+      </Link>
+      <Link
+        to="/budget"
+        className={pathname.startsWith('/budget') ? 'active' : ''}
+      >
+        Budgeting
       </Link>
       <Link
         to="/backlog"
@@ -61,6 +68,8 @@ function PageHeader() {
     title = 'Service Management';
   } else if (pathname.startsWith('/cars')) {
     title = 'Car Management';
+  } else if (pathname.startsWith('/budget')) {
+    title = 'Budgeting';
   } else if (pathname.startsWith('/backlog')) {
     title = 'Backlog';
   } else if (pathname === '/admin/users') {
@@ -82,8 +91,9 @@ export default function App() {
         <Routes>
           <Route path="/" element={<HomePage />} />
           <Route path="/contracts/*" element={<ContractManager />} />
-          <Route path="/cars/*" element={<CarManager />} />  {/* new */}
-          <Route path="/backlog" element={<BacklogManager />} />
+        <Route path="/cars/*" element={<CarManager />} />  {/* new */}
+        <Route path="/budget" element={<BudgetManager />} />
+        <Route path="/backlog" element={<BacklogManager />} />
           <Route path="/admin/users" element={<UserManager />} />
         </Routes>
       </div>

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -126,3 +126,30 @@ export const getBacklogNotes = (itemId) =>
   axios.get(`${API_URL}/backlog-items/${itemId}/notes`);
 export const addBacklogNote = (itemId, text) =>
   axios.post(`${API_URL}/backlog-items/${itemId}/notes`, { text });
+
+// --- Budgeting ---
+export const getBudgetMonths = () => axios.get(`${API_URL}/budget-months`);
+export const createBudgetMonth = data => axios.post(`${API_URL}/budget-months`, data);
+export const updateBudgetMonth = (id, data) => axios.put(`${API_URL}/budget-months/${id}`, data);
+export const deleteBudgetMonth = id => axios.delete(`${API_URL}/budget-months/${id}`);
+export const copyBudgetMonth = (id, fromId) => axios.post(`${API_URL}/budget-months/${id}/copy`, { fromId });
+
+export const getBudgetLines = (monthId) => axios.get(`${API_URL}/budget-months/${monthId}/lines`);
+export const createBudgetLine = (monthId, data) => axios.post(`${API_URL}/budget-months/${monthId}/lines`, data);
+export const updateBudgetLine = (id, data) => axios.put(`${API_URL}/budget-lines/${id}`, data);
+export const deleteBudgetLine = id => axios.delete(`${API_URL}/budget-lines/${id}`);
+
+export const getIncomeSources = (monthId) => axios.get(`${API_URL}/budget-months/${monthId}/incomes`);
+export const createIncomeSource = (monthId, data) => axios.post(`${API_URL}/budget-months/${monthId}/incomes`, data);
+export const updateIncomeSource = (id, data) => axios.put(`${API_URL}/income-sources/${id}`, data);
+export const deleteIncomeSource = id => axios.delete(`${API_URL}/income-sources/${id}`);
+
+export const getSavingPots = () => axios.get(`${API_URL}/saving-pots`);
+export const createSavingPot = data => axios.post(`${API_URL}/saving-pots`, data);
+export const updateSavingPot = (id, data) => axios.put(`${API_URL}/saving-pots/${id}`, data);
+export const deleteSavingPot = id => axios.delete(`${API_URL}/saving-pots/${id}`);
+
+export const getSavingEntries = (potId) => axios.get(`${API_URL}/saving-pots/${potId}/entries`);
+export const createSavingEntry = (potId, data) => axios.post(`${API_URL}/saving-pots/${potId}/entries`, data);
+export const updateSavingEntry = (id, data) => axios.put(`${API_URL}/saving-entries/${id}`, data);
+export const deleteSavingEntry = id => axios.delete(`${API_URL}/saving-entries/${id}`);

--- a/frontend/src/modules/budgetManager/budgetManager.js
+++ b/frontend/src/modules/budgetManager/budgetManager.js
@@ -1,0 +1,157 @@
+import React, { useState, useEffect } from 'react';
+import {
+  getBudgetMonths,
+  createBudgetMonth,
+  updateBudgetMonth,
+  deleteBudgetMonth,
+  copyBudgetMonth,
+  getBudgetLines,
+  createBudgetLine,
+  updateBudgetLine,
+  deleteBudgetLine,
+  getIncomeSources,
+  createIncomeSource,
+  updateIncomeSource,
+  deleteIncomeSource,
+  getSavingPots,
+  createSavingPot,
+  updateSavingPot,
+  deleteSavingPot,
+  getSavingEntries,
+  createSavingEntry,
+  updateSavingEntry,
+  deleteSavingEntry
+} from '../../api';
+
+export default function BudgetManager() {
+  const [months, setMonths] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [lines, setLines] = useState([]);
+  const [incomes, setIncomes] = useState([]);
+  const [pots, setPots] = useState([]);
+  const [entries, setEntries] = useState([]);
+
+  const loadMonths = () => getBudgetMonths().then(r => setMonths(r.data));
+
+  useEffect(() => { loadMonths(); loadPots(); }, []);
+
+  const loadDetails = (monthId) => {
+    getBudgetLines(monthId).then(r => setLines(r.data));
+    getIncomeSources(monthId).then(r => setIncomes(r.data));
+    setSelected(monthId);
+  };
+
+  const loadPots = () => getSavingPots().then(r => setPots(r.data));
+  const loadEntries = (potId) => getSavingEntries(potId).then(r => setEntries(r.data));
+
+  const addMonth = async () => {
+    const month = prompt('Enter month (YYYY-MM)');
+    if (!month) return;
+    await createBudgetMonth({ month });
+    loadMonths();
+  };
+
+  const copyFromPrev = async (id) => {
+    const prevId = prompt('Copy from month id?');
+    if (!prevId) return;
+    await copyBudgetMonth(id, prevId);
+    loadDetails(id);
+  };
+
+  const togglePaid = async (line) => {
+    await updateBudgetLine(line.id, { is_paid: !line.is_paid });
+    loadDetails(selected);
+  };
+
+  return (
+    <div>
+      <h3>Budget Months</h3>
+      <button className="btn btn-primary mb-2" onClick={addMonth}>New Month</button>
+      <table className="fixed-table">
+        <thead>
+          <tr><th>Month</th><th>Actions</th></tr>
+        </thead>
+        <tbody>
+          {months.map(m => (
+            <tr key={m.id}>
+              <td>{m.month}</td>
+              <td className="actions-col">
+                <button className="btn btn-sm btn-secondary" onClick={() => loadDetails(m.id)}>Open</button>
+                <button className="btn btn-sm btn-secondary" onClick={() => copyFromPrev(m.id)}>Copy</button>
+                <button className="btn btn-sm btn-danger" onClick={() => { if(window.confirm('Delete?')) deleteBudgetMonth(m.id).then(loadMonths); }}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {selected && (
+        <div className="modal-backdrop" onClick={() => setSelected(null)}>
+          <div className="modal-content" onClick={e => e.stopPropagation()}>
+            <h4>Month Details</h4>
+            <table className="fixed-table">
+              <thead><tr><th>Name</th><th>Planned</th><th>Actual</th><th>Paid</th></tr></thead>
+              <tbody>
+                {lines.map(line => (
+                  <tr key={line.id} className={line.is_paid ? 'text-success' : ''}>
+                    <td>{line.name}</td>
+                    <td>{line.planned}</td>
+                    <td>{line.actual}</td>
+                    <td><input type="checkbox" checked={line.is_paid} onChange={() => togglePaid(line)} /></td>
+                  </tr>
+                ))}
+                {lines.length === 0 && <tr><td colSpan="4">No lines</td></tr>}
+              </tbody>
+            </table>
+            <h5>Income</h5>
+            <table className="fixed-table">
+              <thead><tr><th>Name</th><th>Amount</th></tr></thead>
+              <tbody>
+                {incomes.map(i => (
+                  <tr key={i.id}><td>{i.name}</td><td>{i.amount}</td></tr>
+                ))}
+                {incomes.length === 0 && <tr><td colSpan="2">No income</td></tr>}
+              </tbody>
+            </table>
+            <button className="btn btn-sm btn-primary mt-2" onClick={() => setSelected(null)}>Close</button>
+          </div>
+        </div>
+      )}
+
+      <h3 style={{marginTop:'2rem'}}>Savings</h3>
+      <button className="btn btn-primary mb-2" onClick={() => {
+        const name = prompt('Pot name');
+        if(name) createSavingPot({ name }).then(loadPots);
+      }}>Add Pot</button>
+      <table className="fixed-table">
+        <thead><tr><th>Name</th><th>Value</th><th>Actions</th></tr></thead>
+        <tbody>
+          {pots.map(p => (
+            <tr key={p.id}>
+              <td>{p.name}</td>
+              <td>{p.current_value}</td>
+              <td className="actions-col">
+                <button className="btn btn-sm btn-secondary" onClick={() => {loadEntries(p.id);}}>
+                  Entries
+                </button>
+                <button className="btn btn-sm btn-danger" onClick={() => { if(window.confirm('Delete?')) deleteSavingPot(p.id).then(loadPots); }}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {entries.length > 0 && (
+        <div className="modal-backdrop" onClick={() => setEntries([])}>
+          <div className="modal-content" onClick={e=>e.stopPropagation()}>
+            <h4>Entries</h4>
+            <ul>
+              {entries.map(e => <li key={e.id}>{e.value}</li>)}
+            </ul>
+            <button className="btn btn-sm btn-primary" onClick={() => setEntries([])}>Close</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add budgeting tables via Sequelize migration
- implement BudgetMonth, BudgetLine, IncomeSource, SavingPot, SavingEntry models
- expose budgeting REST API endpoints
- extend server to load new models
- add frontend API helpers
- create budgeting manager UI and link from nav

## Testing
- `npm test --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db306e8e4832e968a51ba562a307c