### PR TITLE
Improve budget manager UI

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -306,3 +306,23 @@ input:focus, select:focus, textarea:focus {
   background: var(--success);
   color: var(--bg);
 }
+.retired td {
+  background: #e5e5e5;
+  color: #888;
+}
+.icon-btn {
+  background: none;
+  border: none;
+  margin-left: 0.25rem;
+  cursor: pointer;
+}
+.balance {
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+.balance.red { background: var(--danger); color: #fff; }
+.balance.yellow { background: var(--warning); color: var(--blue-dark); }
+.balance.dark-green { background: #065f46; color: var(--bg); }
+.balance.green { background: var(--success); color: var(--bg); }
+.total-row td { font-weight: 600; }

--- a/frontend/src/modules/budgetManager/budgetGrid.js
+++ b/frontend/src/modules/budgetManager/budgetGrid.js
@@ -11,6 +11,7 @@ import {
 export default function BudgetGrid() {
   const [months, setMonths] = useState([]);
   const [linesByMonth, setLinesByMonth] = useState({});
+  const [editing, setEditing] = useState(null); // {monthId, name, value}
 
   const load = async () => {
     const mRes = await getBudgetMonths();
@@ -27,20 +28,29 @@ export default function BudgetGrid() {
   useEffect(() => { load(); }, []);
 
   const addMonth = async () => {
-    const month = prompt('Enter month (YYYY-MM)');
-    if (!month) return;
-    await createBudgetMonth({ month });
+    let month;
+    if (months.length === 0) {
+      const now = new Date();
+      month = now.toISOString().slice(0, 7);
+    } else {
+      const last = months[months.length - 1].month;
+      const [y, m] = last.split('-').map(Number);
+      const d = new Date(y, m - 1, 1);
+      d.setMonth(d.getMonth() + 1);
+      month = d.toISOString().slice(0, 7);
+    }
+    const res = await createBudgetMonth({ month });
+    if (months.length > 0) {
+      const prevId = months[months.length - 1].id;
+      await copyBudgetMonth(res.data.id, prevId);
+    }
     load();
   };
 
-  const copyMonth = async (id) => {
-    const fromId = prompt('Copy from month id?');
-    if (!fromId) return;
-    await copyBudgetMonth(id, fromId);
-    load();
-  };
 
-  const addLine = async (monthId) => {
+  const addLine = async () => {
+    if (months.length === 0) return;
+    const monthId = months[months.length - 1].id;
     const name = prompt('Line name');
     if (!name) return;
     const category = prompt('Category (Income/Bill/Variable/Annual)', 'Bill');
@@ -54,15 +64,14 @@ export default function BudgetGrid() {
     load();
   };
 
-  const updateAmount = async (line) => {
-    const val = prompt('Planned amount', line.planned);
-    if (val === null) return;
-    await updateBudgetLine(line.id, { planned: parseFloat(val) || 0 });
-    load();
-  };
 
-  const disableLine = async (line) => {
-    await updateBudgetLine(line.id, { is_retired: !line.is_retired });
+  const toggleRetired = async (name) => {
+    for (const m of months) {
+      const line = (linesByMonth[m.id] || []).find(l => l.name === name);
+      if (line) {
+        await updateBudgetLine(line.id, { is_retired: !line.is_retired });
+      }
+    }
     load();
   };
 
@@ -88,10 +97,33 @@ export default function BudgetGrid() {
     }
   });
 
+  const totalsByCategory = {};
+  const totals = {};
+  categories.forEach(c => {
+    totalsByCategory[c] = {};
+    months.forEach(m => { totalsByCategory[c][m.id] = 0; });
+  });
+  months.forEach(m => {
+    totals[m.id] = { income: 0, out: 0 };
+    (linesByMonth[m.id] || []).forEach(l => {
+      totalsByCategory[l.category][m.id] += l.planned;
+      if (l.category === 'Income') totals[m.id].income += l.planned;
+      else totals[m.id].out += l.planned;
+    });
+  });
+
+  const balClass = (v) => {
+    if (v < 0) return 'red';
+    if (v < 300) return 'yellow';
+    if (v < 1000) return 'dark-green';
+    return 'green';
+  };
+
   return (
     <div>
-      <div className="mb-2">
+      <div className="mb-2" style={{display:'flex', gap:'0.5rem'}}>
         <button className="btn btn-primary" onClick={addMonth}>Add Month</button>
+        <button className="btn btn-secondary" onClick={addLine}>Add Line</button>
       </div>
       {categories.map(cat => (
         <div key={cat} style={{marginBottom:'2rem'}}>
@@ -102,44 +134,69 @@ export default function BudgetGrid() {
                 <th>Line Item</th>
                 {months.map(m => (
                   <th key={m.id}>
-                    <div style={{display:'flex', justifyContent:'space-between', alignItems:'center'}}>
+                    <div style={{display:'flex', flexDirection:'column', alignItems:'center'}}>
                       <span>{m.month}</span>
-                      <span>
-                        <button className="btn btn-sm btn-secondary" onClick={() => addLine(m.id)}>+</button>
-                        <button className="btn btn-sm btn-secondary" onClick={() => copyMonth(m.id)}>⤵︎</button>
-                      </span>
+                      <span className={`balance ${balClass(totals[m.id].income - totals[m.id].out)}`}>{(totals[m.id].income - totals[m.id].out).toFixed(2)}</span>
                     </div>
                   </th>
                 ))}
               </tr>
             </thead>
             <tbody>
-              {rowsByCategory[cat].map(name => (
-                <tr key={name}>
-                  <td>{name}</td>
+              {rowsByCategory[cat].sort((a,b) => {
+                const la = Object.values(linesByMonth).flat().find(l => l.name===a);
+                const lb = Object.values(linesByMonth).flat().find(l => l.name===b);
+                return (la?.is_retired?1:0)-(lb?.is_retired?1:0);
+              }).map(name => (
+                <tr key={name} className={Object.values(linesByMonth).flat().find(l=>l.name===name)?.is_retired ? 'retired' : ''}>
+                  <td>
+                    {name}
+                    <button className="icon-btn" onClick={() => toggleRetired(name)}>🚫</button>
+                  </td>
                   {months.map(m => {
                     const line = (linesByMonth[m.id] || []).find(l => l.name === name);
-                    if (!line) return <td key={m.id}></td>;
+                    const isEditing = editing && editing.monthId===m.id && editing.name===name;
+                    if (isEditing) {
+                      return (
+                        <td key={m.id}>
+                          <input
+                            type="number"
+                            value={editing.value}
+                            onChange={e => setEditing({...editing, value:e.target.value})}
+                            onBlur={async () => {
+                              const val = parseFloat(editing.value)||0;
+                              if (line) await updateBudgetLine(line.id, { planned: val });
+                              else {
+                                const other = Object.values(linesByMonth).flat().find(l=>l.name===name);
+                                const cat = other ? other.category : 'Bill';
+                                await createBudgetLine(m.id, { name, category: cat, planned: val });
+                              }
+                              setEditing(null);
+                              load();
+                            }}
+                          />
+                        </td>
+                      );
+                    }
                     return (
                       <td
                         key={m.id}
-                        className={line.is_paid ? 'paid-cell' : ''}
-                        onClick={() => togglePaid(line)}
-                        onDoubleClick={() => updateAmount(line)}
+                        className={line && line.is_paid ? 'paid-cell' : ''}
+                        onClick={() => line && togglePaid(line)}
+                        onDoubleClick={() => setEditing({monthId:m.id,name,value:line?line.planned:''})}
                       >
-                        {line.planned}
-                        <button
-                          className="btn btn-sm btn-warning"
-                          style={{marginLeft:'0.25rem'}}
-                          onClick={(e) => { e.stopPropagation(); disableLine(line); }}
-                        >
-                          {line.is_retired ? 'Enable' : 'Disable'}
-                        </button>
+                        {line ? line.planned : ''}
                       </td>
                     );
                   })}
                 </tr>
               ))}
+              <tr className="total-row">
+                <td>Total</td>
+                {months.map(m => (
+                  <td key={m.id}>{totalsByCategory[cat][m.id].toFixed(2)}</td>
+                ))}
+              </tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
## Summary
- add inline editing and disable toggle button
- show remaining balance per month with color indicator
- add per-section totals
- global Add Line button and auto-copy when adding months

## Testing
- `npm test --prefix frontend --watchAll=false` *(fails: react-scripts not found)*
- `npm run build --prefix frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db9f87474832ea80e54b5096c4c5a