### PR TITLE
Fix server model imports

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -22,6 +22,10 @@ require('./models/IncomeSource');
 require('./models/SavingPot');
 require('./models/SavingEntry');
 
+// Bring commonly used models into scope for route handlers
+const Service = require('./models/Service');
+const Attachment = require('./models/Attachment');
+
 const app = express();
 const PORT = process.env.PORT || 4000;
 


### PR DESCRIPTION
## Summary
- import Service and Attachment models in server

## Testing
- `npm --prefix frontend test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbd5bfb74832ebea3679d786bb5fa