### PR TITLE
Add error logging for budget months

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -315,6 +315,7 @@ router.get('/budget-months', async (req, res) => {
     });
     res.json(months);
   } catch (err) {
+    console.error('Get budget months error:', err);
     res.status(500).json({ error: err.message });
   }
 });


### PR DESCRIPTION
## Summary
- log server-side errors when retrieving budget months to diagnose failures

## Testing
- `npm --prefix frontend test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbf5c8e74832ea328832158f1bc85