### PR TITLE
Redesign FinanceManager layout

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -136,6 +136,7 @@ export const updateBudgetLine = (id, data) => axios.put(`${API_URL}/budget-lines
 export const deleteBudgetLine = id => axios.delete(`${API_URL}/budget-lines/${id}`);
 
 export const updateBudgetEntry = (id, data) => axios.put(`${API_URL}/budget-entries/${id}`, data);
+export const createBudgetEntry = data => axios.post(`${API_URL}/budget-entries`, data);
 
 export const createIncomeSource = data => axios.post(`${API_URL}/income-sources`, data);
 export const updateIncomeSource = (id, data) => axios.put(`${API_URL}/income-sources/${id}`, data);

--- a/frontend/src/modules/financeManager/financeManager.js
+++ b/frontend/src/modules/financeManager/financeManager.js
@@ -2,98 +2,164 @@ import React, { useEffect, useState } from 'react';
 import {
   getBudgetMonths,
   createBudgetMonth,
+  getBudgetLines,
+  createBudgetLine,
   updateBudgetEntry,
-  createIncomeSource
+  createBudgetEntry,
+  createIncomeSource,
+  updateIncomeSource
 } from '../../api';
 
-function EntryRow({ entry }) {
-  const [planned, setPlanned] = useState(entry.planned_amount);
-  const [actual, setActual] = useState(entry.actual_amount || '');
-  const [paid, setPaid] = useState(entry.is_paid);
+function EntryCell({ entry, monthId, lineId, reload }) {
+  const [planned, setPlanned] = useState(entry ? entry.planned_amount : '');
+  const [actual, setActual] = useState(entry ? entry.actual_amount || '' : '');
+  const [paid, setPaid] = useState(entry ? entry.is_paid : false);
+
+  useEffect(() => {
+    setPlanned(entry ? entry.planned_amount : '');
+    setActual(entry ? entry.actual_amount || '' : '');
+    setPaid(entry ? entry.is_paid : false);
+  }, [entry]);
 
   const save = () => {
-    updateBudgetEntry(entry.id, {
+    const data = {
       planned_amount: planned || 0,
       actual_amount: actual || null,
       is_paid: paid
-    });
+    };
+    if (entry) {
+      updateBudgetEntry(entry.id, data).then(reload);
+    } else {
+      createBudgetEntry({ ...data, BudgetMonthId: monthId, BudgetLineId: lineId }).then(reload);
+    }
   };
 
   return (
-    <tr>
-      <td>{entry.BudgetLine.name}</td>
-      <td>
-        <input
-          type="number"
-          value={planned}
-          onChange={e => setPlanned(e.target.value)}
-          onBlur={save}
-        />
-      </td>
-      <td>
-        <input
-          type="number"
-          value={actual}
-          onChange={e => setActual(e.target.value)}
-          onBlur={save}
-        />
-      </td>
-      <td>
-        <input
-          type="checkbox"
-          checked={paid}
-          onChange={e => { setPaid(e.target.checked); save(); }}
-        />
-      </td>
-    </tr>
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <input type="number" value={planned} onChange={e => setPlanned(e.target.value)} onBlur={save} style={{ marginBottom: '0.25rem' }} />
+      <input type="number" value={actual} onChange={e => setActual(e.target.value)} onBlur={save} style={{ marginBottom: '0.25rem' }} />
+      <input type="checkbox" checked={paid} onChange={e => { setPaid(e.target.checked); save(); }} />
+    </div>
   );
 }
 
-function Month({ month }) {
-  const incomeTotal = month.IncomeSources.reduce((s,i)=>s+parseFloat(i.amount||0),0);
-  const plannedTotal = month.BudgetEntries.reduce((s,e)=>s+parseFloat(e.planned_amount||0),0);
-  const remaining = incomeTotal - plannedTotal;
+function IncomeCell({ month, name, reload }) {
+  const src = month.IncomeSources.find(i => i.name === name);
+  const [amount, setAmount] = useState(src ? src.amount : '');
 
-  const addIncome = () => {
-    const name = prompt('Source name');
-    const amt = prompt('Amount');
-    if(!name||!amt)return;
-    createIncomeSource({ name, amount: amt, BudgetMonthId: month.id });
+  useEffect(() => {
+    setAmount(src ? src.amount : '');
+  }, [src]);
+
+  const save = () => {
+    if (src) {
+      updateIncomeSource(src.id, { amount: amount || 0 }).then(reload);
+    } else if (amount) {
+      createIncomeSource({ name, amount, BudgetMonthId: month.id }).then(reload);
+    }
   };
 
   return (
-    <div style={{ border:'1px solid #ccc', padding:'1rem', marginBottom:'1rem' }}>
-      <h4>{month.month}</h4>
-      <div>Income: £{incomeTotal.toFixed(2)} | Outgoings: £{plannedTotal.toFixed(2)} | Remaining: £{remaining.toFixed(2)}</div>
-      <button className="btn btn-sm btn-secondary" onClick={addIncome}>Add Income</button>
-      <table className="fixed-table" style={{ marginTop:'0.5rem' }}>
-        <thead>
-          <tr>
-            <th>Line</th><th>Planned</th><th>Actual</th><th>Paid</th>
-          </tr>
-        </thead>
-        <tbody>
-          {month.BudgetEntries.map(entry => <EntryRow key={entry.id} entry={entry} />)}
-        </tbody>
-      </table>
-    </div>
+    <input type="number" value={amount} onChange={e => setAmount(e.target.value)} onBlur={save} style={{ marginBottom: 0 }} />
   );
 }
 
 export default function FinanceManager() {
   const [months, setMonths] = useState([]);
+  const [lines, setLines] = useState([]);
 
-  const load = () => getBudgetMonths().then(r => setMonths(r.data));
+  const load = () => {
+    Promise.all([getBudgetMonths(), getBudgetLines()]).then(([m, l]) => {
+      setMonths(m.data);
+      setLines(l.data);
+    });
+  };
 
   useEffect(() => { load(); }, []);
 
   const addMonth = () => createBudgetMonth().then(load);
 
+  const addLine = type => {
+    const name = prompt('Line name');
+    if (!name) return;
+    createBudgetLine({ name, type }).then(res => {
+      const line = res.data;
+      Promise.all(months.map(m => createBudgetEntry({ BudgetMonthId: m.id, BudgetLineId: line.id }))).then(load);
+    });
+  };
+
+  const addIncomeRow = () => {
+    const name = prompt('Income source name');
+    if (!name) return;
+    Promise.all(months.map(m => createIncomeSource({ name, amount: 0, BudgetMonthId: m.id }))).then(load);
+  };
+
+  const incomeNames = Array.from(new Set(months.flatMap(m => m.IncomeSources.map(i => i.name))));
+  const bills = lines.filter(l => l.type === 'BILL' && !l.is_retired);
+  const variables = lines.filter(l => l.type === 'VARIABLE' && !l.is_retired);
+  const annuals = lines.filter(l => l.type === 'ANNUAL' && !l.is_retired);
+
   return (
     <div className="container">
       <h3>Budget</h3>
       <button className="btn btn-primary mb-2" onClick={addMonth}>Add Month</button>
-      {months.map(m => <Month key={m.id} month={m} />)}
+      <table className="fixed-table">
+        <thead>
+          <tr>
+            <th>Line</th>
+            {months.map(m => <th key={m.id}>{m.month}</th>)}
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th colSpan={months.length + 1}>Income <button className="btn btn-sm btn-secondary" onClick={addIncomeRow}>Add Income</button></th>
+          </tr>
+          {incomeNames.map(name => (
+            <tr key={`inc-${name}`}>
+              <td>{name}</td>
+              {months.map(m => (
+                <td key={m.id}><IncomeCell month={m} name={name} reload={load} /></td>
+              ))}
+            </tr>
+          ))}
+          <tr>
+            <th colSpan={months.length + 1}>Bills <button className="btn btn-sm btn-secondary" onClick={() => addLine('BILL')}>Add Bill</button></th>
+          </tr>
+          {bills.map(line => (
+            <tr key={line.id}>
+              <td>{line.name}</td>
+              {months.map(m => {
+                const entry = m.BudgetEntries.find(e => e.BudgetLineId === line.id);
+                return <td key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
+              })}
+            </tr>
+          ))}
+          <tr>
+            <th colSpan={months.length + 1}>Variable <button className="btn btn-sm btn-secondary" onClick={() => addLine('VARIABLE')}>Add Variable</button></th>
+          </tr>
+          {variables.map(line => (
+            <tr key={line.id}>
+              <td>{line.name}</td>
+              {months.map(m => {
+                const entry = m.BudgetEntries.find(e => e.BudgetLineId === line.id);
+                return <td key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
+              })}
+            </tr>
+          ))}
+          <tr>
+            <th colSpan={months.length + 1}>Annual <button className="btn btn-sm btn-secondary" onClick={() => addLine('ANNUAL')}>Add Annual</button></th>
+          </tr>
+          {annuals.map(line => (
+            <tr key={line.id}>
+              <td>{line.name}</td>
+              {months.map(m => {
+                const entry = m.BudgetEntries.find(e => e.BudgetLineId === line.id);
+                return <td key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update API helper to support creating budget entries
- redesign Finance Manager UI
  - show months as columns
  - sections for Income, Bills, Variable and Annual lines
  - inline editing for each cell
- provide controls to add months, income sources and budget lines

## Testing
- `npm test --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684dda497824832ea1521801d29d920b