### PR TITLE
Improve budget UI

### DIFF
--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -781,8 +781,15 @@ router.get('/budget-months', async (req, res) => {
 router.post('/budget-months', async (req, res) => {
   try {
     const last = await BudgetMonth.findOne({ order: [['month', 'DESC']] });
-    let nextDate = last ? new Date(last.month + '-01') : new Date();
-    if (last) nextDate.setMonth(nextDate.getMonth() + 1);
+    let nextDate;
+    if (last) {
+      // Parse last.month in UTC to avoid timezone issues
+      const [y, m] = last.month.split('-').map(Number);
+      nextDate = new Date(Date.UTC(y, m - 1, 1));
+      nextDate.setUTCMonth(nextDate.getUTCMonth() + 1);
+    } else {
+      nextDate = new Date();
+    }
     const monthStr = nextDate.toISOString().slice(0,7);
     const month = await BudgetMonth.create({ month: monthStr });
 


### PR DESCRIPTION
## Summary
- enable unlimited month creation by using UTC date math
- simplify budget entry UI to a single editable amount and paid toggle
- wrap budget table in scrollable container

## Testing
- `npm test --silent` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ddc8a74f8832e8007f8fe392a4dfe