### PR TITLE
Improve finance table layout

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -90,6 +90,19 @@ table {
 .fixed-table td {
   word-wrap: break-word;
 }
+/* Finance table layout */
+.finance-table {
+  width: max-content; /* allow horizontal scroll when many months */
+}
+.finance-table th.line-name,
+.finance-table td.line-name {
+  width: 220px; /* generous width for line item name */
+}
+.finance-table th.month-col,
+.finance-table td.month-col {
+  min-width: 90px; /* enough space for month header */
+  white-space: nowrap;
+}
 /* Stack action buttons vertically */
 .action-buttons {
   display: flex;

--- a/frontend/src/modules/financeManager/financeManager.js
+++ b/frontend/src/modules/financeManager/financeManager.js
@@ -147,11 +147,11 @@ export default function FinanceManager() {
       <h3>Budget</h3>
       <button className="btn btn-primary mb-2" onClick={addMonth}>Add Month</button>
       <div style={{ overflowX: 'auto' }}>
-      <table className="fixed-table">
+      <table className="finance-table">
         <thead>
           <tr>
-            <th>Line</th>
-            {months.map(m => <th key={m.id}>{m.month}</th>)}
+            <th className="line-name">Line</th>
+            {months.map(m => <th className="month-col" key={m.id}>{m.month}</th>)}
           </tr>
         </thead>
         <tbody>
@@ -160,9 +160,9 @@ export default function FinanceManager() {
           </tr>
           {incomeNames.map(name => (
             <tr key={`inc-${name}`}>
-              <td>{name}</td>
+              <td className="line-name">{name}</td>
               {months.map(m => (
-                <td key={m.id}><IncomeCell month={m} name={name} reload={load} /></td>
+                <td className="month-col" key={m.id}><IncomeCell month={m} name={name} reload={load} /></td>
               ))}
             </tr>
           ))}
@@ -171,10 +171,10 @@ export default function FinanceManager() {
           </tr>
           {bills.map(line => (
             <tr key={line.id}>
-              <td>{line.name}</td>
+              <td className="line-name">{line.name}</td>
               {months.map(m => {
                 const entry = m.BudgetEntries.find(e => e.BudgetLineId === line.id);
-                return <td key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
+                return <td className="month-col" key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
               })}
             </tr>
           ))}
@@ -183,10 +183,10 @@ export default function FinanceManager() {
           </tr>
           {variables.map(line => (
             <tr key={line.id}>
-              <td>{line.name}</td>
+              <td className="line-name">{line.name}</td>
               {months.map(m => {
                 const entry = m.BudgetEntries.find(e => e.BudgetLineId === line.id);
-                return <td key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
+                return <td className="month-col" key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
               })}
             </tr>
           ))}
@@ -195,10 +195,10 @@ export default function FinanceManager() {
           </tr>
           {annuals.map(line => (
             <tr key={line.id}>
-              <td>{line.name}</td>
+              <td className="line-name">{line.name}</td>
               {months.map(m => {
                 const entry = m.BudgetEntries.find(e => e.BudgetLineId === line.id);
-                return <td key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
+                return <td className="month-col" key={m.id}><EntryCell entry={entry} monthId={m.id} lineId={line.id} reload={load} /></td>;
               })}
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- widen finance line item column and allow months to scroll
- add finance table style overrides

## Testing
- `npm --prefix frontend test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dde9693dc832ea31957e8f22988d0