### PR TITLE
Improve finance table UX

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -100,8 +100,23 @@ table {
 }
 .finance-table th.month-col,
 .finance-table td.month-col {
-  min-width: 90px; /* enough space for month header */
+  min-width: 45px; /* slimmer month columns */
   white-space: nowrap;
+}
+
+.section-header th {
+  background: var(--blue-mid);
+  font-weight: bold;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+
+.remaining-row th {
+  background: var(--blue-dark);
+  position: sticky;
+  top: 0;
+  z-index: 1;
 }
 /* Stack action buttons vertically */
 .action-buttons {


### PR DESCRIPTION
## Summary
- format numbers as GBP
- darken paid cell background and fix default amount
- shrink month columns
- add remaining budget row
- make section headers styled

## Testing
- `npm test --silent` *(fails: registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684de0e514dc832eb38fe86ce819edd8