### PR TITLE
Add month copy option and toggleable budget lines

### DIFF
--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -129,6 +129,7 @@ export const addBacklogNote = (itemId, text) =>
 // --- Budget Module ---
 export const getBudgetMonths = () => axios.get(`${API_URL}/budget-months`);
 export const createBudgetMonth = () => axios.post(`${API_URL}/budget-months`);
+export const copyBudgetMonth = () => axios.post(`${API_URL}/budget-months/copy`);
 
 export const getBudgetLines = () => axios.get(`${API_URL}/budget-lines`);
 export const createBudgetLine = data => axios.post(`${API_URL}/budget-lines`, data);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -100,13 +100,14 @@ table {
 }
 .finance-table th.month-col,
 .finance-table td.month-col {
-  min-width: 45px; /* slimmer month columns */
+  min-width: 35px; /* slimmer month columns */
   white-space: nowrap;
 }
 
 .section-header th {
   background: var(--blue-mid);
   font-weight: bold;
+  color: var(--accent);
   position: sticky;
   top: 0;
   z-index: 2;
@@ -117,6 +118,28 @@ table {
   position: sticky;
   top: 0;
   z-index: 1;
+}
+
+/* Small toggle button next to line names */
+.line-toggle {
+  margin-left: 0.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--accent);
+}
+
+.retired-line {
+  opacity: 0.6;
+}
+
+.disabled-cell {
+  color: var(--blue-light);
+}
+
+.add-action {
+  width: 100px;
+  margin-left: 0.5rem;
 }
 /* Stack action buttons vertically */
 .action-buttons {


### PR DESCRIPTION
## Summary
- allow copying of latest month entries and income via new endpoint
- surface `copyBudgetMonth` API and hook it up in FinanceManager
- enable disabling of budget lines with a small toggle button and style
- show retired lines at the bottom with greyed read‑only cells
- make month columns slimmer and tweak section header colors
- style add-line buttons and rename sections

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de5720238832e9e3a10e59fa1bfb3