### PR TITLE
Fix missing model imports

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -54,6 +54,7 @@ app.use('/api', routes);
 
 // ---- Attachment upload route (add after app.use('/api', routes)) ----
 require('./models'); // Loads all, registers associations
+const { Service, Attachment } = require('./models');
 
 
 app.post('/api/services/:serviceId/attachments', upload.single('file'), async (req, res) => {


### PR DESCRIPTION
## Summary
- load `Service` and `Attachment` from the models index in `server.js` to allow attachment upload route to access them

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e72fd81e0832ebc7fcfa1b60c7e6b