### PR TITLE
Add Jest test setup

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "src/server.js",
   "scripts": {
-    "dev": "nodemon src/server.js"
+    "dev": "nodemon src/server.js",
+    "test": "jest"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
@@ -15,6 +16,7 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "jest": "^29.7.0"
   }
 }

--- a/backend/tests/service.test.js
+++ b/backend/tests/service.test.js
@@ -1,0 +1,10 @@
+const sequelize = require('../src/db');
+const Service = require('../src/models/Service');
+
+beforeAll(() => sequelize.sync({ force: true }));
+afterAll(() => sequelize.close());
+
+test('creates a Service record', async () => {
+  const svc = await Service.create({ name: 'Test Service' });
+  expect(svc.id).toBeDefined();
+});


### PR DESCRIPTION
## Summary
- add Jest dev dependency and test script to backend
- add initial Service model test

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e78519ea0832e90a55252d20f4647