### PR TITLE
Fix contract form and service model

### DIFF
--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -30,7 +30,8 @@ Subcategory.hasMany(Service,    { onDelete: 'CASCADE' });
 Service.belongsTo(Subcategory,  { foreignKey: { allowNull: false } });
 
 Frequency.hasMany(Service,    { onDelete: 'RESTRICT' });
-Service.belongsTo(Frequency,  { foreignKey: { allowNull: false } });
+// Frequency is optional so allow null
+Service.belongsTo(Frequency,  { foreignKey: { allowNull: true } });
 
 BacklogItem.hasMany(Attachment, { foreignKey: 'BacklogItemId', onDelete: 'CASCADE' });
 Attachment.belongsTo(BacklogItem, { foreignKey: 'BacklogItemId' });

--- a/frontend/src/modules/contractManager/contractForm.js
+++ b/frontend/src/modules/contractManager/contractForm.js
@@ -86,10 +86,12 @@ export default function ContractForm({ existing, onSaved, onCancel }) {
 
     const payload = {
       ...service,
-      cost: Number(service.cost),
+      cost: service.cost ? Number(service.cost) : null,
+      start_date: service.start_date || null,
+      next_due_date: service.next_due_date || null,
       VendorId: Number(service.VendorId),
       SubcategoryId: Number(service.SubcategoryId),
-      FrequencyId: Number(service.FrequencyId)
+      FrequencyId: service.FrequencyId ? Number(service.FrequencyId) : null,
     };
 
     const action = existing


### PR DESCRIPTION
## Summary
- allow optional frequency ID in Service associations
- send nulls for blank fields when saving contracts

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e904847ec832ebfef8a817f54bc4f