### PR TITLE
Update Node version notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ The backend exposes REST endpoints for managing contracts, cars, backlog items a
 
 ## Prerequisites
 
-- Node.js (18 or later recommended)
+- **Backend Node.js version:** Node 18 LTS is supported and tested. Other Node.js
+  versions may fail to load the `sqlite3` module used by the backend.
 - npm
 
 ## Installation


### PR DESCRIPTION
## Summary
- document that Node 18 LTS is tested for the backend
- mention that other Node versions may fail to load sqlite3

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9c8f5458832e97060986de5d559d