### PR TITLE
Fix attachment filename storage

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -68,13 +68,13 @@ app.post('/api/services/:serviceId/attachments', upload.single('file'), async (r
     const service = await Service.findByPk(serviceId);
     if (!service) return res.status(404).json({ error: 'Service not found' });
 
-    const attachment = await Attachment.create({
-      ServiceId: serviceId,
-      filename: req.file.originalname,
-      stored_filename: req.file.filename, // To use the unique file on disk
-      mimetype: req.file.mimetype,
-      size: req.file.size,
-    });
+  const attachment = await Attachment.create({
+    ServiceId: serviceId,
+    filename: req.file.filename,
+    originalname: req.file.originalname,
+    mimetype: req.file.mimetype,
+    size: req.file.size,
+  });
     res.status(201).json(attachment);
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- use `filename` for stored upload name in server.js

## Testing
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9de6b4bc832eb8e3ec580f2f3732