### PR TITLE
Fix missing columns for Service table

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -86,7 +86,7 @@ app.post('/api/services/:serviceId/attachments', upload.single('file'), async (r
   try {
     await sequelize.authenticate();
     console.log('✅ Database connected');
-    await sequelize.sync();
+    await sequelize.sync({ alter: true });
     console.log('✅ Database synced');
     app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure Sequelize can automatically add missing columns by using `sync({ alter: true })`

## Testing
- `npm test` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684eb70a0788832eb884daa23e1dbf8a