### PR TITLE
Add API tests

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const cors = require('cors');
+const multer = require('multer');
+const path = require('path');
+const sequelize = require('./db');
+const routes = require('./routes');
+
+// Load all models and associations
+require('./models');
+const { Service, Attachment } = require('./models');
+
+const app = express();
+const uploadDir = path.join(__dirname, 'uploads');
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    cb(null, uploadDir);
+  },
+  filename: function (req, file, cb) {
+    cb(null, Date.now() + '-' + file.originalname);
+  }
+});
+const upload = multer({ storage });
+
+app.use('/uploads', express.static(path.join(__dirname, '..', 'uploads')));
+app.use(cors());
+app.use(express.json());
+app.use('/uploads', express.static(uploadDir));
+app.use('/api', routes);
+
+app.post('/api/services/:serviceId/attachments', upload.single('file'), async (req, res) => {
+  const { serviceId } = req.params;
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  try {
+    const service = await Service.findByPk(serviceId);
+    if (!service) return res.status(404).json({ error: 'Service not found' });
+
+    const attachment = await Attachment.create({
+      ServiceId: serviceId,
+      filename: req.file.filename,
+      originalname: req.file.originalname,
+      mimetype: req.file.mimetype,
+      size: req.file.size,
+    });
+    res.status(201).json(attachment);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = { app, sequelize };

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,9 +1,12 @@
 const { Sequelize } = require('sequelize');
 const path = require('path');
 
+const storage = process.env.DB_STORAGE ||
+  path.join(__dirname, '../database.sqlite');
+
 module.exports = new Sequelize({
   dialect: 'sqlite',
-  storage: path.join(__dirname, '../database.sqlite'),
+  storage,
   logging: false,
 });
 

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,0 +1,59 @@
+const { app, sequelize } = require('../src/app');
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  process.env.DB_STORAGE = ':memory:';
+  await sequelize.sync({ force: true });
+  server = app.listen(0);
+  await new Promise(resolve => server.on('listening', resolve));
+  const port = server.address().port;
+  baseUrl = `http://localhost:${port}/api`;
+});
+
+afterAll(async () => {
+  await sequelize.close();
+  server.close();
+});
+
+beforeEach(async () => {
+  await sequelize.sync({ force: true });
+});
+
+test('register and login user', async () => {
+  let res = await fetch(baseUrl + '/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'bob', email: 'bob@e.com', password: 'secret' })
+  });
+  expect(res.status).toBe(201);
+
+  res = await fetch(baseUrl + '/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'bob', password: 'secret' })
+  });
+  expect(res.status).toBe(200);
+  const data = await res.json();
+  expect(data.token).toBeDefined();
+});
+
+test('create and list cars', async () => {
+  let res = await fetch(baseUrl + '/cars');
+  expect(res.status).toBe(200);
+  let list = await res.json();
+  expect(Array.isArray(list)).toBe(true);
+  expect(list.length).toBe(0);
+
+  res = await fetch(baseUrl + '/cars', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ make: 'Ford', model: 'Focus', year: 2020 })
+  });
+  expect(res.status).toBe(201);
+
+  res = await fetch(baseUrl + '/cars');
+  list = await res.json();
+  expect(list.length).toBe(1);
+  expect(list[0].make).toBe('Ford');
+});


### PR DESCRIPTION
## Summary
- enable custom DB storage path
- refactor backend server into reusable app
- add API integration tests to hit register/login and cars endpoints

## Testing
- `npm test` *(fails: cannot load sqlite3 module)*

------
https://chatgpt.com/codex/tasks/task_e_684eb882ed34832eb2ba7d9590969d7a