### PR TITLE
Fix server sync behaviour

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,7 +5,7 @@ const PORT = process.env.PORT || 4000;
   try {
     await sequelize.authenticate();
     console.log('✅ Database connected');
-    await sequelize.sync({ alter: true });
+    await sequelize.sync();
     console.log('✅ Database synced');
     app.listen(PORT, () => console.log(`Server listening on port ${PORT}`));
   } catch (err) {


### PR DESCRIPTION
## Summary
- don't drop tables when starting the server

## Testing
- `npm test` *(fails: sqlite3 invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_684ebb1129b0832ea407edbad03f08a1