### PR TITLE
Add admin-only house plans backend

### DIFF
--- a/backend/migrations/20250801-add-house-plans.js
+++ b/backend/migrations/20250801-add-house-plans.js
@@ -1,0 +1,105 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('HousePlans', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      title: { type: Sequelize.STRING, allowNull: false },
+      description: { type: Sequelize.TEXT },
+      status: { type: Sequelize.STRING, defaultValue: 'planned' },
+      budget: { type: Sequelize.DECIMAL(10,2), defaultValue: 0 },
+      actualSpend: { type: Sequelize.DECIMAL(10,2), defaultValue: 0 },
+      startDate: { type: Sequelize.DATE },
+      endDate: { type: Sequelize.DATE },
+      createdBy: { type: Sequelize.INTEGER, references: { model: 'Users', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      deletedAt: { type: Sequelize.DATE }
+    });
+
+    await queryInterface.createTable('HousePlanLineItems', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      title: { type: Sequelize.STRING },
+      description: { type: Sequelize.TEXT },
+      estimate: { type: Sequelize.DECIMAL(10,2) },
+      actualSpend: { type: Sequelize.DECIMAL(10,2), defaultValue: 0 },
+      startDate: { type: Sequelize.DATE },
+      endDate: { type: Sequelize.DATE },
+      HousePlanId: {
+        type: Sequelize.UUID,
+        references: { model: 'HousePlans', key: 'id' },
+        allowNull: false,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE'
+      },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      deletedAt: { type: Sequelize.DATE }
+    });
+
+    await queryInterface.createTable('HousePlanQuotes', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      vendor: { type: Sequelize.STRING },
+      amount: { type: Sequelize.DECIMAL(10,2) },
+      dateReceived: { type: Sequelize.DATE },
+      notes: { type: Sequelize.TEXT },
+      HousePlanLineItemId: {
+        type: Sequelize.UUID,
+        references: { model: 'HousePlanLineItems', key: 'id' },
+        allowNull: false,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE'
+      },
+      attachmentId: { type: Sequelize.INTEGER, references: { model: 'Attachments', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      deletedAt: { type: Sequelize.DATE }
+    });
+
+    await queryInterface.createTable('HousePlanInvoices', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      vendor: { type: Sequelize.STRING },
+      amount: { type: Sequelize.DECIMAL(10,2) },
+      dateIssued: { type: Sequelize.DATE },
+      paid: { type: Sequelize.BOOLEAN, defaultValue: false },
+      HousePlanLineItemId: {
+        type: Sequelize.UUID,
+        references: { model: 'HousePlanLineItems', key: 'id' },
+        allowNull: false,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE'
+      },
+      attachmentId: { type: Sequelize.INTEGER, references: { model: 'Attachments', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      deletedAt: { type: Sequelize.DATE }
+    });
+
+    await queryInterface.createTable('HousePlanTasks', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      title: { type: Sequelize.STRING },
+      description: { type: Sequelize.TEXT },
+      status: { type: Sequelize.STRING, defaultValue: 'not_started' },
+      dueDate: { type: Sequelize.DATE },
+      HousePlanLineItemId: {
+        type: Sequelize.UUID,
+        references: { model: 'HousePlanLineItems', key: 'id' },
+        allowNull: false,
+        onDelete: 'CASCADE',
+        onUpdate: 'CASCADE'
+      },
+      assignedTo: { type: Sequelize.INTEGER, references: { model: 'Users', key: 'id' }, onDelete: 'SET NULL', onUpdate: 'CASCADE' },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      deletedAt: { type: Sequelize.DATE }
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('HousePlanTasks');
+    await queryInterface.dropTable('HousePlanInvoices');
+    await queryInterface.dropTable('HousePlanQuotes');
+    await queryInterface.dropTable('HousePlanLineItems');
+    await queryInterface.dropTable('HousePlans');
+  }
+};

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,0 +1,30 @@
+const jwt = require('jsonwebtoken');
+const { User } = require('../models');
+const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+
+async function authenticate(req, res, next) {
+  const header = req.headers['authorization'];
+  if (!header) return res.status(401).json({ error: 'Missing token' });
+  const token = header.split(' ')[1];
+  if (!token) return res.status(401).json({ error: 'Missing token' });
+  try {
+    const decoded = jwt.verify(token, JWT_SECRET);
+    const user = await User.findByPk(decoded.id);
+    if (!user) return res.status(401).json({ error: 'Invalid token' });
+    req.user = user;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+function requireRole(role) {
+  return (req, res, next) => {
+    if (!req.user || req.user.role !== role) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}
+
+module.exports = { authenticate, requireRole };

--- a/backend/src/models/HousePlan.js
+++ b/backend/src/models/HousePlan.js
@@ -1,0 +1,16 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const HousePlan = sequelize.define('HousePlan', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  title: { type: DataTypes.STRING, allowNull: false },
+  description: { type: DataTypes.TEXT },
+  status: { type: DataTypes.STRING, defaultValue: 'planned' },
+  budget: { type: DataTypes.DECIMAL(10,2), defaultValue: 0 },
+  actualSpend: { type: DataTypes.DECIMAL(10,2), defaultValue: 0 },
+  startDate: { type: DataTypes.DATE },
+  endDate: { type: DataTypes.DATE },
+  createdBy: { type: DataTypes.INTEGER },
+}, { paranoid: true });
+
+module.exports = HousePlan;

--- a/backend/src/models/HousePlanInvoice.js
+++ b/backend/src/models/HousePlanInvoice.js
@@ -1,0 +1,12 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const HousePlanInvoice = sequelize.define('HousePlanInvoice', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  vendor: { type: DataTypes.STRING },
+  amount: { type: DataTypes.DECIMAL(10,2) },
+  dateIssued: { type: DataTypes.DATE },
+  paid: { type: DataTypes.BOOLEAN, defaultValue: false },
+}, { paranoid: true });
+
+module.exports = HousePlanInvoice;

--- a/backend/src/models/HousePlanLineItem.js
+++ b/backend/src/models/HousePlanLineItem.js
@@ -1,0 +1,14 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const HousePlanLineItem = sequelize.define('HousePlanLineItem', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  title: { type: DataTypes.STRING },
+  description: { type: DataTypes.TEXT },
+  estimate: { type: DataTypes.DECIMAL(10,2) },
+  actualSpend: { type: DataTypes.DECIMAL(10,2), defaultValue: 0 },
+  startDate: { type: DataTypes.DATE },
+  endDate: { type: DataTypes.DATE },
+}, { paranoid: true });
+
+module.exports = HousePlanLineItem;

--- a/backend/src/models/HousePlanQuote.js
+++ b/backend/src/models/HousePlanQuote.js
@@ -1,0 +1,12 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const HousePlanQuote = sequelize.define('HousePlanQuote', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  vendor: { type: DataTypes.STRING },
+  amount: { type: DataTypes.DECIMAL(10,2) },
+  dateReceived: { type: DataTypes.DATE },
+  notes: { type: DataTypes.TEXT },
+}, { paranoid: true });
+
+module.exports = HousePlanQuote;

--- a/backend/src/models/HousePlanTask.js
+++ b/backend/src/models/HousePlanTask.js
@@ -1,0 +1,12 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const HousePlanTask = sequelize.define('HousePlanTask', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  title: { type: DataTypes.STRING },
+  description: { type: DataTypes.TEXT },
+  status: { type: DataTypes.STRING, defaultValue: 'not_started' },
+  dueDate: { type: DataTypes.DATE },
+}, { paranoid: true });
+
+module.exports = HousePlanTask;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -18,6 +18,11 @@ const BudgetEntry  = require('./BudgetEntry');
 const IncomeSource = require('./IncomeSource');
 const SavingsPot   = require('./SavingsPot');
 const SavingsEntry = require('./SavingsEntry');
+const HousePlan = require('./HousePlan');
+const HousePlanLineItem = require('./HousePlanLineItem');
+const HousePlanQuote = require('./HousePlanQuote');
+const HousePlanInvoice = require('./HousePlanInvoice');
+const HousePlanTask = require('./HousePlanTask');
 
 // Associations:
 Service.hasMany(Attachment, { foreignKey: 'ServiceId', onDelete: 'CASCADE' });
@@ -50,6 +55,18 @@ SavingsEntry.belongsTo(SavingsPot, { foreignKey: 'SavingsPotId' });
 BudgetMonth.hasMany(SavingsEntry, { foreignKey: 'BudgetMonthId', onDelete: 'CASCADE' });
 SavingsEntry.belongsTo(BudgetMonth, { foreignKey: 'BudgetMonthId' });
 
+// House Plan associations
+HousePlan.hasMany(HousePlanLineItem, { foreignKey: 'HousePlanId', onDelete: 'CASCADE' });
+HousePlanLineItem.belongsTo(HousePlan, { foreignKey: 'HousePlanId' });
+HousePlanLineItem.hasMany(HousePlanQuote, { foreignKey: 'HousePlanLineItemId', onDelete: 'CASCADE' });
+HousePlanQuote.belongsTo(HousePlanLineItem, { foreignKey: 'HousePlanLineItemId' });
+HousePlanLineItem.hasMany(HousePlanInvoice, { foreignKey: 'HousePlanLineItemId', onDelete: 'CASCADE' });
+HousePlanInvoice.belongsTo(HousePlanLineItem, { foreignKey: 'HousePlanLineItemId' });
+HousePlanLineItem.hasMany(HousePlanTask, { foreignKey: 'HousePlanLineItemId', onDelete: 'CASCADE' });
+HousePlanTask.belongsTo(HousePlanLineItem, { foreignKey: 'HousePlanLineItemId' });
+HousePlanTask.belongsTo(User, { as: 'assignedUser', foreignKey: 'assignedTo' });
+User.hasMany(HousePlanTask, { foreignKey: 'assignedTo' });
+
 module.exports = {
   Service,
   Attachment,
@@ -71,4 +88,9 @@ module.exports = {
   IncomeSource,
   SavingsPot,
   SavingsEntry,
+  HousePlan,
+  HousePlanLineItem,
+  HousePlanQuote,
+  HousePlanInvoice,
+  HousePlanTask,
 };

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -26,6 +26,13 @@ const BudgetEntry   = require('./models/BudgetEntry');
 const IncomeSource  = require('./models/IncomeSource');
 const SavingsPot    = require('./models/SavingsPot');
 const SavingsEntry  = require('./models/SavingsEntry');
+const HousePlan = require('./models/HousePlan');
+const HousePlanLineItem = require('./models/HousePlanLineItem');
+const HousePlanQuote = require('./models/HousePlanQuote');
+const HousePlanInvoice = require('./models/HousePlanInvoice');
+const HousePlanTask = require('./models/HousePlanTask');
+
+const { authenticate, requireRole } = require('./middleware/auth');
 
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
@@ -908,5 +915,207 @@ crud('budget-entries', BudgetEntry);
 crud('income-sources', IncomeSource);
 crud('savings-pots', SavingsPot);
 crud('savings-entries', SavingsEntry);
+
+// ----- House Plans -----
+
+async function recalcLineItemSpend(lineItemId) {
+  const invoices = await HousePlanInvoice.findAll({ where: { HousePlanLineItemId: lineItemId } });
+  const total = invoices.reduce((acc, inv) => acc + parseFloat(inv.amount || 0), 0);
+  await HousePlanLineItem.update({ actualSpend: total }, { where: { id: lineItemId } });
+  const item = await HousePlanLineItem.findByPk(lineItemId);
+  if (item) await recalcPlanSpend(item.HousePlanId);
+}
+
+async function recalcPlanSpend(planId) {
+  const items = await HousePlanLineItem.findAll({ where: { HousePlanId: planId } });
+  const total = items.reduce((acc, it) => acc + parseFloat(it.actualSpend || 0), 0);
+  await HousePlan.update({ actualSpend: total }, { where: { id: planId } });
+}
+
+router.get('/house-plans', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const plans = await HousePlan.findAll({
+      include: [{
+        model: HousePlanLineItem,
+        include: [HousePlanQuote, HousePlanInvoice, { model: HousePlanTask, include: [{ model: User, as: 'assignedUser' }] }]
+      }]
+    });
+    const data = plans.map(p => {
+      const obj = p.toJSON();
+      const tasks = obj.HousePlanLineItems.flatMap(li => li.HousePlanTasks);
+      const completed = tasks.filter(t => t.status === 'done').length;
+      obj.completion = tasks.length ? Math.round((completed / tasks.length) * 100) : 0;
+      return obj;
+    });
+    res.json(data);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/house-plans', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const plan = await HousePlan.create({ ...req.body, createdBy: req.user.id });
+    res.status(201).json(plan);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/house-plans/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const [updated] = await HousePlan.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/house-plans/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const deleted = await HousePlan.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.get('/house-plan-line-items', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const items = await HousePlanLineItem.findAll({ include: [HousePlan] });
+    res.json(items);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/house-plan-line-items', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const item = await HousePlanLineItem.create(req.body);
+    await recalcPlanSpend(item.HousePlanId);
+    res.status(201).json(item);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/house-plan-line-items/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const [updated] = await HousePlanLineItem.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    const item = await HousePlanLineItem.findByPk(req.params.id);
+    if (item) await recalcPlanSpend(item.HousePlanId);
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/house-plan-line-items/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const item = await HousePlanLineItem.findByPk(req.params.id);
+    const deleted = await HousePlanLineItem.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    if (item) await recalcPlanSpend(item.HousePlanId);
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/house-plan-invoices', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const inv = await HousePlanInvoice.create(req.body);
+    await recalcLineItemSpend(inv.HousePlanLineItemId);
+    res.status(201).json(inv);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/house-plan-invoices/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const [updated] = await HousePlanInvoice.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    const inv = await HousePlanInvoice.findByPk(req.params.id);
+    if (inv) await recalcLineItemSpend(inv.HousePlanLineItemId);
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/house-plan-invoices/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const inv = await HousePlanInvoice.findByPk(req.params.id);
+    const deleted = await HousePlanInvoice.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    if (inv) await recalcLineItemSpend(inv.HousePlanLineItemId);
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/house-plan-quotes', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const q = await HousePlanQuote.create(req.body);
+    res.status(201).json(q);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/house-plan-quotes/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const [updated] = await HousePlanQuote.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/house-plan-quotes/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const deleted = await HousePlanQuote.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/house-plan-tasks', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const task = await HousePlanTask.create(req.body);
+    res.status(201).json(task);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.put('/house-plan-tasks/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const [updated] = await HousePlanTask.update(req.body, { where: { id: req.params.id } });
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+router.delete('/house-plan-tasks/:id', authenticate, requireRole('admin'), async (req, res) => {
+  try {
+    const deleted = await HousePlanTask.destroy({ where: { id: req.params.id } });
+    if (!deleted) return res.status(404).json({ error: 'Not found' });
+    res.sendStatus(204);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 
 module.exports = router;

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -57,3 +57,43 @@ test('create and list cars', async () => {
   expect(list.length).toBe(1);
   expect(list[0].make).toBe('Ford');
 });
+
+test('house plan endpoints require admin', async () => {
+  let res = await fetch(baseUrl + '/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'admin', email: 'a@a.com', password: 'pw', role: 'admin' })
+  });
+  expect(res.status).toBe(201);
+
+  res = await fetch(baseUrl + '/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'admin', password: 'pw' })
+  });
+  const adminToken = (await res.json()).token;
+
+  res = await fetch(baseUrl + '/house-plans', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + adminToken },
+    body: JSON.stringify({ title: 'Renovation', status: 'planned', budget: 1000 })
+  });
+  expect(res.status).toBe(201);
+
+  await fetch(baseUrl + '/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'user', email: 'u@u.com', password: 'pw' })
+  });
+  res = await fetch(baseUrl + '/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'user', password: 'pw' })
+  });
+  const userToken = (await res.json()).token;
+
+  res = await fetch(baseUrl + '/house-plans', {
+    headers: { Authorization: 'Bearer ' + userToken }
+  });
+  expect(res.status).toBe(403);
+});


### PR DESCRIPTION
## Summary
- add data models and DB migration for house plan tracking
- create auth middleware with role checks
- implement admin-only REST endpoints for managing house plans
- test that house plan endpoints are admin restricted

## Testing
- `npm test` *(fails: sqlite3 invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_685835a2e350832ea1fdfccc4ee0a2fb