### PR TITLE
Add spin wheel reward system

### DIFF
--- a/backend/src/models/SpinHistory.js
+++ b/backend/src/models/SpinHistory.js
@@ -1,0 +1,10 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const SpinHistory = sequelize.define('SpinHistory', {
+  ip:         { type: DataTypes.STRING, allowNull: false },
+  resultLabel:{ type: DataTypes.STRING },
+  resultType: { type: DataTypes.STRING },
+});
+
+module.exports = SpinHistory;

--- a/backend/src/models/SpinSegment.js
+++ b/backend/src/models/SpinSegment.js
@@ -1,0 +1,10 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const SpinSegment = sequelize.define('SpinSegment', {
+  label:  { type: DataTypes.STRING, allowNull: false },
+  type:   { type: DataTypes.STRING, allowNull: false },
+  weight: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 1 },
+});
+
+module.exports = SpinSegment;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -23,6 +23,8 @@ const HousePlanLineItem = require('./HousePlanLineItem');
 const HousePlanQuote = require('./HousePlanQuote');
 const HousePlanInvoice = require('./HousePlanInvoice');
 const HousePlanTask = require('./HousePlanTask');
+const SpinSegment = require('./SpinSegment');
+const SpinHistory = require('./SpinHistory');
 
 // Associations:
 Service.hasMany(Attachment, { foreignKey: 'ServiceId', onDelete: 'CASCADE' });
@@ -93,4 +95,6 @@ module.exports = {
   HousePlanQuote,
   HousePlanInvoice,
   HousePlanTask,
+  SpinSegment,
+  SpinHistory,
 };

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -1117,5 +1117,39 @@ router.delete('/house-plan-tasks/:id', authenticate, requireRole('admin'), async
   }
 });
 
+// --------- Spin Wheel ---------
+const { SpinSegment, SpinHistory } = require('./models');
+
+router.get('/spin-config', async (req, res) => {
+  const segments = await SpinSegment.findAll({ order: [['id', 'ASC']] });
+  res.json(segments);
+});
+
+router.put('/spin-config', authenticate, requireRole('admin'), async (req, res) => {
+  await SpinSegment.destroy({ where: {} });
+  await SpinSegment.bulkCreate(req.body);
+  const segments = await SpinSegment.findAll({ order: [['id', 'ASC']] });
+  res.json(segments);
+});
+
+router.post('/spin', async (req, res) => {
+  const ip = req.ip;
+  const last = await SpinHistory.findOne({ where: { ip }, order: [['createdAt', 'DESC']] });
+  if (last && Date.now() - new Date(last.createdAt).getTime() < 24 * 60 * 60 * 1000) {
+    return res.status(429).json({ error: 'Daily spin limit reached' });
+  }
+  const segments = await SpinSegment.findAll();
+  if (!segments.length) return res.status(400).json({ error: 'No segments configured' });
+  const total = segments.reduce((sum, s) => sum + s.weight, 0);
+  let rnd = Math.random() * total;
+  let chosen = segments[0];
+  for (const seg of segments) {
+    if (rnd < seg.weight) { chosen = seg; break; }
+    rnd -= seg.weight;
+  }
+  await SpinHistory.create({ ip, resultLabel: chosen.label, resultType: chosen.type });
+  res.json({ label: chosen.label, type: chosen.type });
+});
+
 
 module.exports = router;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,8 @@ import BacklogManager from './modules/backlogManager/backlogManager';
 import UserManager from './modules/userManager/userManager';
 import FinanceManager from './modules/financeManager/financeManager';
 import ThemeToggle from './components/ui/ThemeToggle';
+import SpinWheel from './modules/spinWheel/SpinWheel';
+import AdminSpinConfig from './modules/spinWheel/AdminSpinConfig';
 
 function NavTabs() {
   const { pathname } = useLocation();
@@ -48,6 +50,12 @@ function NavTabs() {
         Finance
       </Link>
       <Link
+        to="/spin"
+        className={pathname.startsWith('/spin') ? 'active' : ''}
+      >
+        Spin Wheel
+      </Link>
+      <Link
         to="/admin/users"
         className={pathname === '/admin/users' ? 'active' : ''}
       >
@@ -72,8 +80,12 @@ function PageHeader() {
     title = 'Backlog';
   } else if (pathname.startsWith('/finance')) {
     title = 'Finance';
+  } else if (pathname.startsWith('/spin')) {
+    title = 'Spin Wheel';
   } else if (pathname === '/admin/users') {
     title = 'User Management (Admin Only)';
+  } else if (pathname === '/admin/spin') {
+    title = 'Spin Config';
   } else {
     title = '';
   }
@@ -94,6 +106,8 @@ export default function App() {
           <Route path="/cars/*" element={<CarManager />} />  {/* new */}
         <Route path="/backlog" element={<BacklogManager />} />
         <Route path="/finance" element={<FinanceManager />} />
+        <Route path="/spin" element={<SpinWheel />} />
+        <Route path="/admin/spin" element={<AdminSpinConfig />} />
         <Route path="/admin/users" element={<UserManager />} />
         </Routes>
       </div>

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -152,4 +152,9 @@ export const createSavingsEntry = data => axios.post(`${API_URL}/savings-entries
 export const updateSavingsEntry = (id, data) => axios.put(`${API_URL}/savings-entries/${id}`, data);
 export const deleteSavingsEntry = id => axios.delete(`${API_URL}/savings-entries/${id}`);
 
+// --- Spin Wheel ---
+export const getSpinConfig = () => axios.get(`${API_URL}/spin-config`);
+export const saveSpinConfig = data => axios.put(`${API_URL}/spin-config`, data);
+export const spin = () => axios.post(`${API_URL}/spin`);
+
 export { UPLOADS_URL };

--- a/frontend/src/modules/spinWheel/AdminSpinConfig.js
+++ b/frontend/src/modules/spinWheel/AdminSpinConfig.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { getSpinConfig, saveSpinConfig } from '../../api';
+
+export default function AdminSpinConfig() {
+  const [segments, setSegments] = useState([]);
+
+  const load = () => getSpinConfig().then(res => setSegments(res.data));
+
+  useEffect(() => { load(); }, []);
+
+  const handleChange = (idx, field, value) => {
+    const updated = [...segments];
+    updated[idx] = { ...updated[idx], [field]: value };
+    setSegments(updated);
+  };
+
+  const addRow = () => setSegments([...segments, { label: '', type: '', weight: 1 }]);
+
+  const save = () => saveSpinConfig(segments).then(load);
+
+  return (
+    <div className="container">
+      <h3>Spin Config</h3>
+      <table>
+        <thead><tr><th>Label</th><th>Type</th><th>Weight</th></tr></thead>
+        <tbody>
+          {segments.map((s,i) => (
+            <tr key={i}>
+              <td><input value={s.label} onChange={e=>handleChange(i,'label',e.target.value)} /></td>
+              <td><input value={s.type} onChange={e=>handleChange(i,'type',e.target.value)} /></td>
+              <td><input type="number" value={s.weight} onChange={e=>handleChange(i,'weight',parseInt(e.target.value,10)||0)} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <button className="btn btn-secondary" onClick={addRow}>Add</button>
+      <button className="btn btn-primary" onClick={save} style={{marginLeft:'0.5rem'}}>Save</button>
+    </div>
+  );
+}

--- a/frontend/src/modules/spinWheel/SpinWheel.js
+++ b/frontend/src/modules/spinWheel/SpinWheel.js
@@ -1,0 +1,46 @@
+import React, { useEffect, useState } from 'react';
+import { getSpinConfig, spin } from '../../api';
+import './spinWheel.css';
+
+export default function SpinWheel() {
+  const [segments, setSegments] = useState([]);
+  const [result, setResult] = useState(null);
+  const [spinning, setSpinning] = useState(false);
+
+  useEffect(() => {
+    getSpinConfig().then(res => setSegments(res.data));
+  }, []);
+
+  const handleSpin = async () => {
+    if (spinning) return;
+    setSpinning(true);
+    try {
+      const res = await spin();
+      setTimeout(() => {
+        setResult(res.data);
+        setSpinning(false);
+      }, 1500);
+    } catch (err) {
+      setResult({ error: err.response?.data?.error || 'Spin failed' });
+      setSpinning(false);
+    }
+  };
+
+  const rotation = spinning ? { transform: 'rotate(720deg)' } : {};
+
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <div className="wheel" style={rotation}>
+        {segments.map(s => (
+          <div key={s.id} className="segment">{s.label}</div>
+        ))}
+      </div>
+      <button className="btn btn-primary" onClick={handleSpin} disabled={spinning}>Spin</button>
+      {result && (
+        <div style={{ marginTop: '1rem' }}>
+          {result.error ? result.error : `You won: ${result.label}`}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/modules/spinWheel/spinWheel.css
+++ b/frontend/src/modules/spinWheel/spinWheel.css
@@ -1,0 +1,17 @@
+.wheel {
+  margin: 1rem auto;
+  width: 200px;
+  height: 200px;
+  border: 6px solid #ccc;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 1.5s ease-out;
+}
+.segment {
+  position: absolute;
+  width: 50%;
+  text-align: center;
+  transform-origin: 100% 50%;
+}


### PR DESCRIPTION
## Summary
- add models and routes for spin wheel configuration
- expose API helpers for spinning and config
- implement SpinWheel and AdminSpinConfig React components
- add navigation to spin wheel pages

## Testing
- `npm test` *(fails: sqlite3 invalid ELF header)*

------
https://chatgpt.com/codex/tasks/task_e_687276e511b0832e990f20da6f11acf1