### PR TITLE
Implement activity filter backend

### DIFF
--- a/backend/migrations/20250910-add-activities.js
+++ b/backend/migrations/20250910-add-activities.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('Activities', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      name: { type: Sequelize.STRING, allowNull: false },
+      description: Sequelize.TEXT,
+      defaultPriceLevel: Sequelize.INTEGER,
+      defaultIndoorOutdoor: Sequelize.ENUM('indoor', 'outdoor', 'both'),
+      defaultEducationalValue: Sequelize.ENUM('low', 'medium', 'high'),
+      isHomeBased: { type: Sequelize.BOOLEAN, defaultValue: false },
+      physicalDemand: Sequelize.ENUM('low', 'medium', 'high'),
+      lastChosenDate: Sequelize.DATE,
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+
+    await queryInterface.createTable('Locations', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      name: { type: Sequelize.STRING, allowNull: false },
+      address: Sequelize.STRING,
+      milesFromHome: Sequelize.DECIMAL(10,2),
+      tags: Sequelize.TEXT,
+      websiteUrl: Sequelize.STRING,
+      isClosed: { type: Sequelize.BOOLEAN, defaultValue: false },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+
+    await queryInterface.createTable('ActivityLocations', {
+      id: { type: Sequelize.UUID, primaryKey: true, defaultValue: Sequelize.UUIDV4 },
+      ActivityId: {
+        type: Sequelize.UUID,
+        references: { model: 'Activities', key: 'id' },
+        onDelete: 'CASCADE', onUpdate: 'CASCADE'
+      },
+      LocationId: {
+        type: Sequelize.UUID,
+        references: { model: 'Locations', key: 'id' },
+        onDelete: 'CASCADE', onUpdate: 'CASCADE'
+      },
+      priceLevelOverride: Sequelize.INTEGER,
+      indoorOutdoorOverride: Sequelize.ENUM('indoor', 'outdoor', 'both'),
+      educationalValueOverride: Sequelize.ENUM('low', 'medium', 'high'),
+      notes: Sequelize.TEXT,
+      isActive: { type: Sequelize.BOOLEAN, defaultValue: true },
+      createdAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+      updatedAt: { type: Sequelize.DATE, allowNull: false, defaultValue: Sequelize.literal('CURRENT_TIMESTAMP') },
+    });
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable('ActivityLocations');
+    await queryInterface.dropTable('Locations');
+    await queryInterface.dropTable('Activities');
+  }
+};

--- a/backend/src/models/Activity.js
+++ b/backend/src/models/Activity.js
@@ -1,0 +1,16 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const Activity = sequelize.define('Activity', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  name: { type: DataTypes.STRING, allowNull: false },
+  description: DataTypes.TEXT,
+  defaultPriceLevel: DataTypes.INTEGER,
+  defaultIndoorOutdoor: DataTypes.ENUM('indoor', 'outdoor', 'both'),
+  defaultEducationalValue: DataTypes.ENUM('low', 'medium', 'high'),
+  isHomeBased: { type: DataTypes.BOOLEAN, defaultValue: false },
+  physicalDemand: DataTypes.ENUM('low', 'medium', 'high'),
+  lastChosenDate: DataTypes.DATE,
+});
+
+module.exports = Activity;

--- a/backend/src/models/ActivityLocation.js
+++ b/backend/src/models/ActivityLocation.js
@@ -1,0 +1,13 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const ActivityLocation = sequelize.define('ActivityLocation', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  priceLevelOverride: DataTypes.INTEGER,
+  indoorOutdoorOverride: DataTypes.ENUM('indoor', 'outdoor', 'both'),
+  educationalValueOverride: DataTypes.ENUM('low', 'medium', 'high'),
+  notes: DataTypes.TEXT,
+  isActive: { type: DataTypes.BOOLEAN, defaultValue: true },
+});
+
+module.exports = ActivityLocation;

--- a/backend/src/models/Location.js
+++ b/backend/src/models/Location.js
@@ -1,0 +1,23 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../db');
+
+const Location = sequelize.define('Location', {
+  id: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4 },
+  name: { type: DataTypes.STRING, allowNull: false },
+  address: DataTypes.STRING,
+  milesFromHome: DataTypes.DECIMAL(10,2),
+  tags: {
+    type: DataTypes.TEXT,
+    get() {
+      const raw = this.getDataValue('tags');
+      return raw ? JSON.parse(raw) : [];
+    },
+    set(val) {
+      this.setDataValue('tags', JSON.stringify(val || []));
+    }
+  },
+  websiteUrl: DataTypes.STRING,
+  isClosed: { type: DataTypes.BOOLEAN, defaultValue: false },
+});
+
+module.exports = Location;

--- a/backend/src/models/index.js
+++ b/backend/src/models/index.js
@@ -25,6 +25,9 @@ const HousePlanInvoice = require('./HousePlanInvoice');
 const HousePlanTask = require('./HousePlanTask');
 const SpinSegment = require('./SpinSegment');
 const SpinHistory = require('./SpinHistory');
+const Activity = require('./Activity');
+const Location = require('./Location');
+const ActivityLocation = require('./ActivityLocation');
 
 // Associations:
 Service.hasMany(Attachment, { foreignKey: 'ServiceId', onDelete: 'CASCADE' });
@@ -69,6 +72,9 @@ HousePlanTask.belongsTo(HousePlanLineItem, { foreignKey: 'HousePlanLineItemId' }
 HousePlanTask.belongsTo(User, { as: 'assignedUser', foreignKey: 'assignedTo' });
 User.hasMany(HousePlanTask, { foreignKey: 'assignedTo' });
 
+Activity.belongsToMany(Location, { through: ActivityLocation });
+Location.belongsToMany(Activity, { through: ActivityLocation });
+
 module.exports = {
   Service,
   Attachment,
@@ -97,4 +103,7 @@ module.exports = {
   HousePlanTask,
   SpinSegment,
   SpinHistory,
+  Activity,
+  Location,
+  ActivityLocation,
 };

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -31,6 +31,9 @@ const HousePlanLineItem = require('./models/HousePlanLineItem');
 const HousePlanQuote = require('./models/HousePlanQuote');
 const HousePlanInvoice = require('./models/HousePlanInvoice');
 const HousePlanTask = require('./models/HousePlanTask');
+const Activity = require('./models/Activity');
+const Location = require('./models/Location');
+const ActivityLocation = require('./models/ActivityLocation');
 
 const { authenticate, requireRole } = require('./middleware/auth');
 
@@ -1149,6 +1152,83 @@ router.post('/spin', async (req, res) => {
   }
   await SpinHistory.create({ ip, resultLabel: chosen.label, resultType: chosen.type });
   res.json({ label: chosen.label, type: chosen.type });
+});
+
+// --------- Activities ---------
+router.get('/activities/filter', async (req, res) => {
+  const parseArray = (v) => {
+    if (!v) return undefined;
+    return Array.isArray(v) ? v : String(v).split(',');
+  };
+
+  try {
+    const all = await ActivityLocation.findAll({
+      where: { isActive: true },
+      include: [
+        { model: Activity },
+        { model: Location, where: { isClosed: false } }
+      ]
+    });
+
+    let results = all.map(al => {
+      const act = al.Activity;
+      const loc = al.Location;
+      return {
+        activityId: act.id,
+        activityName: act.name,
+        locationName: loc.name,
+        priceLevel: al.priceLevelOverride ?? act.defaultPriceLevel,
+        indoorOutdoor: al.indoorOutdoorOverride ?? act.defaultIndoorOutdoor,
+        educationalValue: al.educationalValueOverride ?? act.defaultEducationalValue,
+        milesFromHome: parseFloat(loc.milesFromHome),
+        lastChosenDate: act.lastChosenDate,
+        locationTags: loc.tags,
+        websiteUrl: loc.websiteUrl,
+        physicalDemand: act.physicalDemand,
+        isHomeBased: act.isHomeBased,
+      };
+    });
+
+    const distanceMax = parseFloat(req.query.distanceMax);
+    const locationTags = parseArray(req.query.locationTags);
+    const priceLevels = parseArray(req.query.priceLevels)?.map(n => parseInt(n));
+    const indoorOutdoor = parseArray(req.query.indoorOutdoor);
+    const educationalValue = parseArray(req.query.educationalValue);
+    const physicalDemandLevels = parseArray(req.query.physicalDemandLevels);
+    const homeBasedOnly = req.query.homeBasedOnly === 'true';
+
+    results = results.filter(r => {
+      if (!isNaN(distanceMax) && r.milesFromHome > distanceMax) return false;
+      if (homeBasedOnly && !r.isHomeBased) return false;
+      if (locationTags && !locationTags.every(t => r.locationTags.includes(t))) return false;
+      if (priceLevels && !priceLevels.includes(r.priceLevel)) return false;
+      if (indoorOutdoor && !indoorOutdoor.includes(r.indoorOutdoor)) return false;
+      if (educationalValue && !educationalValue.includes(r.educationalValue)) return false;
+      if (physicalDemandLevels && !physicalDemandLevels.includes(r.physicalDemand)) return false;
+      return true;
+    });
+
+    const sortBy = req.query.sortBy;
+    if (sortBy === 'distance') results.sort((a,b) => a.milesFromHome - b.milesFromHome);
+    if (sortBy === 'price') results.sort((a,b) => (a.priceLevel ?? 0) - (b.priceLevel ?? 0));
+    if (sortBy === 'lastChosen') results.sort((a,b) => new Date(b.lastChosenDate||0) - new Date(a.lastChosenDate||0));
+    if (sortBy === 'alphabetical') results.sort((a,b) => a.activityName.localeCompare(b.activityName));
+
+    res.json(results);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.patch('/activities/:id/last-chosen', async (req, res) => {
+  try {
+    const act = await Activity.findByPk(req.params.id);
+    if (!act) return res.status(404).json({ error: 'Not found' });
+    await act.update({ lastChosenDate: req.body.lastChosenDate || new Date() });
+    res.json({ lastChosenDate: act.lastChosenDate });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
 });
 
 

--- a/backend/src/seed.js
+++ b/backend/src/seed.js
@@ -3,6 +3,9 @@ const Category   = require('./models/Category');
 const Subcategory= require('./models/Subcategory');
 const Vendor     = require('./models/vendor');
 const Frequency  = require('./models/Frequency');
+const Activity = require('./models/Activity');
+const Location = require('./models/Location');
+const ActivityLocation = require('./models/ActivityLocation');
 
 async function seed() {
   await sequelize.sync();
@@ -18,6 +21,36 @@ async function seed() {
   }
   // Example vendor
   await Vendor.findOrCreate({ where:{ name:'Netflix' } });
+
+  // Activities and locations example
+  const [swimming] = await Activity.findOrCreate({
+    where: { name: 'Swimming' },
+    defaults: {
+      description: 'Go for a swim',
+      defaultPriceLevel: 2,
+      defaultIndoorOutdoor: 'indoor',
+      defaultEducationalValue: 'medium',
+      isHomeBased: false,
+      physicalDemand: 'medium',
+    }
+  });
+
+  const [leisure] = await Location.findOrCreate({
+    where: { name: 'Knutsford Leisure Centre' },
+    defaults: {
+      address: 'Knutsford',
+      milesFromHome: 3.2,
+      tags: JSON.stringify(['near Knutsford']),
+      websiteUrl: 'https://example.com',
+      isClosed: false,
+    }
+  });
+
+  await ActivityLocation.findOrCreate({
+    where: { ActivityId: swimming.id, LocationId: leisure.id },
+    defaults: { isActive: true }
+  });
+
   console.log('✅ Seed complete');
   process.exit();
 }

--- a/backend/tests/activity-filter.test.js
+++ b/backend/tests/activity-filter.test.js
@@ -1,0 +1,59 @@
+const { app, sequelize } = require('../src/app');
+const { Activity, Location, ActivityLocation } = require('../src/models');
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  process.env.DB_STORAGE = ':memory:';
+  await sequelize.sync({ force: true });
+  server = app.listen(0);
+  await new Promise(resolve => server.on('listening', resolve));
+  baseUrl = `http://localhost:${server.address().port}/api`;
+});
+
+afterAll(async () => {
+  await sequelize.close();
+  server.close();
+});
+
+beforeEach(async () => {
+  await sequelize.sync({ force: true });
+});
+
+test('filter endpoint returns activity-location combos', async () => {
+  const act = await Activity.create({
+    name: 'Swimming',
+    defaultPriceLevel: 2,
+    defaultIndoorOutdoor: 'indoor',
+    defaultEducationalValue: 'medium',
+    isHomeBased: false,
+    physicalDemand: 'medium'
+  });
+  const loc = await Location.create({ name: 'Pool', milesFromHome: 5, tags: JSON.stringify(['family']) });
+  await ActivityLocation.create({ ActivityId: act.id, LocationId: loc.id, isActive: true });
+
+  const res = await fetch(`${baseUrl}/activities/filter?distanceMax=10`);
+  const data = await res.json();
+  expect(res.status).toBe(200);
+  expect(data.length).toBe(1);
+  expect(data[0].activityName).toBe('Swimming');
+});
+
+test('patch last chosen date', async () => {
+  const act = await Activity.create({
+    name: 'Painting',
+    defaultPriceLevel: 1,
+    defaultIndoorOutdoor: 'indoor',
+    defaultEducationalValue: 'high',
+    isHomeBased: true,
+    physicalDemand: 'low'
+  });
+  const res = await fetch(`${baseUrl}/activities/${act.id}/last-chosen`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ lastChosenDate: '2025-01-01' })
+  });
+  expect(res.status).toBe(200);
+  const updated = await Activity.findByPk(act.id);
+  expect(updated.lastChosenDate).toBe('2025-01-01T00:00:00.000Z');
+});


### PR DESCRIPTION
## Summary
- create Activity/Location models and association table
- expose API to filter activities with overrides resolved
- patch endpoint to update activity lastChosenDate
- seed example activities/locations
- add migrations and tests

## Testing
- `npm test` *(fails: sqlite3 binary not usable)*

------
https://chatgpt.com/codex/tasks/task_e_6883f5eeff04832eba192444d3d1e18f